### PR TITLE
added helper to ease transition from previous ie8 approaches

### DIFF
--- a/_sass-utils/_mixins.scss
+++ b/_sass-utils/_mixins.scss
@@ -17,3 +17,15 @@
 @mixin nUiConfigureDebug() {
 	/*! n-ui features: #{inspect($_n-ui-features)} */
 }
+
+@mixin nUiIe8Only () {
+	@if variable-exists('_n-ui-is-ie8') or $o-grid-ie8-rules == 'only' {
+	 	@content
+	}
+}
+
+@mixin nUiNotIe8 () {
+	@if not (variable-exists('_n-ui-is-ie8') or $o-grid-ie8-rules == 'only') {
+	 	@content
+	}
+}


### PR DESCRIPTION
@i-like-robots @ironsidevsquincy 

Because retrofitting the new ie8 stylesheet generation to existing apps  (e.g front-page) is nigh on impossible without having some way to prevent output of style blocks