### PR TITLE
Add nGetImage mixin

### DIFF
--- a/icons/main.scss
+++ b/icons/main.scss
@@ -37,6 +37,38 @@ $o-icons-service-base-url: 'https://next-geebee.ft.com/image';
 	}
 }
 
+@mixin nGetImage($image-type, $image-name, $color: null, $container-width: 128, $container-height: null, $apply-base-styles: true, $apply-width-height: true) {
+	$url: 'https://next-geebee.ft.com/image/v1/images/raw/ft#{$image-type}:#{$image-name}';
+	$query: '?source=next';
+
+	@if $color != null {
+		$color: str-slice(ie-hex-str($color), 4);
+		$query: $query + "&tint=%23#{$color},%23#{$color}";
+	}
+
+	background-image: url($url + $query + '&format=svg');
+
+	// ie7/8 fallback. Uses the `\9` selector hack to target ie6-8.
+	// Hack is documented here: http://browserhacks.com/#hack-ab1bcc7b3a6544c99260f7608f8e845e
+	// It still needs to use the build service  <-- what does this comment mean?
+	background-image: url($url + $query + '&format=png&width=#{$container-width}')\9;
+
+	// Prevents dimension styles being output by default.
+	// Resolves issue where previous component `o-ft-icons` the mixin this replaces,
+	// dimension styles were included within the $apply-base-styles block as well.
+	@if ($apply-width-height == true) {
+		width: $container-width + 0px;
+		@if ($container-height == null) {
+			$container-height: $container-width;
+		}
+		height: $container-height + 0px;
+	}
+
+	@if ($apply-base-styles == true) {
+		@include oIconsBaseStyles;
+	}
+}
+
 @if $_n-ui-icons-applied == false {
 
 	$_n-ui-icons-applied: true;


### PR DESCRIPTION
Basically a copy of [`oIconsGetIcon`](https://github.com/Financial-Times/o-icons/blob/master/scss/_mixins.scss#L14), except takes a first parameter of the image 'type', e.g. 'icon', 'logo', 'head' (see http://image.webservices.ft.com/v1/#uri)

cc: @wheresrhys 