### PR TITLE
make colspan extend for each layout optional

### DIFF
--- a/grid/main.scss
+++ b/grid/main.scss
@@ -35,7 +35,7 @@ $o-grid-shuffle-selectors: false;
 
 		@each $layout-name in $_o-grid-layout-names {
 			[data-o-grid-colspan~="#{$layout-name}hide"] {
-				@extend [data-o-grid-colspan~="#{$layout-name}0"];
+				@extend [data-o-grid-colspan~="#{$layout-name}0"] !optional;
 			}
 		}
 


### PR DESCRIPTION
to cater for apps using a fixed o-grid layout, which may omit some

@wheresrhys 