### PR TITLE
Load gpt and ads-api in parallel

### DIFF
--- a/ads/test/index.spec.js
+++ b/ads/test/index.spec.js
@@ -22,7 +22,7 @@ describe('Main', () => {
 
 	it('Should init if flag is set to true and appname given', () => {
 		const flags = { get: () => true };
-		const initSpy = sandbox.stub(ads, 'init', () => ({ slots: { initSlot: sinon.stub() }}));
+		const initSpy = sandbox.stub(ads, 'init', () => ({ slots: { initSlot: sinon.stub()}, config: sinon.stub() }));
 		return main.onload(flags).then(() => {
 			expect(initSpy).to.have.been.called;
 		});
@@ -41,7 +41,7 @@ describe('Main', () => {
 	it('Should bind the adverts found on page to o-ads library', () => {
 		const flags = { get: () => true };
 		const adInit = sandbox.spy(ads.slots, 'initSlot');
-		sandbox.stub(ads, 'init', () => ({slots: { initSlot: adInit } }));
+		sandbox.stub(ads, 'init', () => ({slots: { initSlot: adInit }, config: sinon.stub }));
 		return main.onload(flags).then(() => {
 			expect(adInit).to.have.been.called;
 		});


### PR DESCRIPTION
@VladDubrovskis @andrewgeorgiou1981 @leggsimon @wheresrhys 

A bit hacky, but call init(withoutTargeting), and then call oAds.config(withAllTargeting) before initSlot is called. Should speed things up a wee bit.

Previously:
[ads-api/user, ads-api/content] -> GPT calls -> Ad calls

Now: 
[ads-api/user, ads-api/content, GPT calls] -> Ad calls