### PR TITLE
Track first ad loaded

### DIFF
--- a/ads/index.js
+++ b/ads/index.js
@@ -74,7 +74,7 @@ function onAdsComplete (event) {
 			utils.log.info('Ad loaded in slot', event);
 			if (slotsRendered === 0) {
 				perfMark('firstAdLoaded');
-				const firstAdLoaded = performance.getEntriesByType ?
+				const marks = performance.getEntriesByType ?
 					performance.getEntriesByType('mark')
 						.filter(mark => mark.name === 'firstAdLoaded')
 						.reduce((marks, mark) => {
@@ -86,7 +86,7 @@ function onAdsComplete (event) {
 				broadcast('oTracking.event', {
 					category: 'page-load',
 					action: 'timing',
-					timings: { firstAdLoaded }
+					timings: { marks }
 				});
 			}
 		} else if (detail.slot.gpt && detail.slot.gpt.isEmpty === true) {

--- a/ads/index.js
+++ b/ads/index.js
@@ -7,8 +7,6 @@ const jsonpFetch = require('n-jsonp');
 
 import { perfMark } from '../utils'
 import { broadcast } from '../utils'
-import { getMarks } from 'n-instrumentation';
-
 
 let slotCount;
 let slotsRendered = 0;

--- a/ads/index.js
+++ b/ads/index.js
@@ -6,6 +6,7 @@ const oAdsConfig = require('./js/oAdsConfig');
 const jsonpFetch = require('n-jsonp');
 
 import { perfMark } from '../utils'
+import { broadcast } from '../utils'
 
 let slotCount;
 let slotsRendered = 0;
@@ -73,6 +74,20 @@ function onAdsComplete (event) {
 			utils.log.info('Ad loaded in slot', event);
 			if (slotsRendered === 0) {
 				perfMark('firstAdLoaded');
+				const firstAdLoaded = performance.getEntriesByType ?
+					performance.getEntriesByType('mark')
+						.filter(mark => mark.name === 'firstAdLoaded')
+						.reduce((marks, mark) => {
+							marks[mark.name] = Math.round(mark.startTime);
+							return marks;
+						}, {}) :
+					{};
+
+				broadcast('oTracking.event', {
+					category: 'page-load',
+					action: 'timing',
+					timings: { firstAdLoaded }
+				});
 			}
 		} else if (detail.slot.gpt && detail.slot.gpt.isEmpty === true) {
 			utils.log.warn('Failed to load ad, details below');

--- a/ads/index.js
+++ b/ads/index.js
@@ -92,20 +92,31 @@ function onAdsComplete (event) {
 }
 
 function sendAdLoadedTrackingEvent() {
-	const marks = performance.getEntriesByType ?
-		performance.getEntriesByName('firstAdLoaded')
-			.reduce((marks, mark) => {
-				marks[mark.name] = Math.round(mark.startTime);
-				return marks;
-			}, {}) :
-		{};
+	const performance = window.performance || window.msPerformance || window.webkitPerformance || window.mozPerformance;
+	if (performance && performance.mark) {
+		const currentTime = new Date().getTime();
+		const offsets = {
+			domContentLoadedEventEnd: {
+				firstAdLoaded: currentTime - performance.timing['domContentLoadedEventEnd'],
+				loadEventEnd: currentTime - performance.timing['loadEventEnd'],
+				domInteractive: currentTime - performance.timing['domInteractive']
+			}
+		};
 
-	broadcast('oTracking.event', {
-		category: 'page-load',
-		action: 'timing',
-		timings: { marks }
-	});
+		const marks = performance.getEntriesByType ?
+			performance.getEntriesByName('firstAdLoaded')
+				.reduce((marks, mark) => {
+					marks[mark.name] = Math.round(mark.startTime);
+					return marks;
+				}, {}) :
+			{};
 
+		broadcast('oTracking.event', {
+			category: 'ads',
+			action: 'first-load',
+			timings: { offsets, marks }
+		});
+	}
 }
 
 

--- a/ads/index.js
+++ b/ads/index.js
@@ -73,8 +73,8 @@ function onAdsComplete (event) {
 		if (detail.slot.gpt && detail.slot.gpt.isEmpty === false) {
 			utils.log.info('Ad loaded in slot', event);
 			if (slotsRendered === 0) {
+				perfMark('firstAdLoaded');
 				if (!/spoor-id=0/.test(document.cookie)) {
-					perfMark('firstAdLoaded');
 					sendAdLoadedTrackingEvent();
 				}
 			}

--- a/ads/index.js
+++ b/ads/index.js
@@ -93,8 +93,7 @@ function onAdsComplete (event) {
 
 function sendAdLoadedTrackingEvent() {
 	const marks = performance.getEntriesByType ?
-		performance.getEntriesByType('mark')
-			.filter(mark => mark.name === 'firstAdLoaded')
+		performance.getEntriesByName('firstAdLoaded')
 			.reduce((marks, mark) => {
 				marks[mark.name] = Math.round(mark.startTime);
 				return marks;


### PR DESCRIPTION
Adding an oTracking event to gather `firstAdLoaded` performance mark. The `firstAdLoaded` mark was previously being very rarely sent using `n-instrumentation` due to the `onLoad` event happening before the first ad was being loaded.

cc/ @adgad @commuterjoy @ironsidevsquincy @wheresrhys 