### PR TITLE
Add: Flags as argument to header-new init function

### DIFF
--- a/header/index.js
+++ b/header/index.js
@@ -1,7 +1,7 @@
 function init (flags) {
 
 	if (flags.get('newHeader')) {
-		require('n-header-footer/header_new').init();
+		require('n-header-footer/header_new').init(flags);
 
 		if (flags.get('fancyDrawer')) {
 			require('n-header-footer/drawer').init();


### PR DESCRIPTION
cc @i-like-robots 

Required when adding typeahead to `n-header-footer/header_new/index.js`, as per implementation on control: https://github.com/Financial-Times/n-header-footer/blob/master/main.js#L18