### PR TITLE
added nUiCritical mixin

### DIFF
--- a/_sass-utils/_mixins.scss
+++ b/_sass-utils/_mixins.scss
@@ -2,6 +2,20 @@
 /// @group n-ui mixins
 ////
 
+/// Critical block
+/// @output A critical block start comment
+@mixin nUiCritical() {
+	@if nUiHas('critical') {
+		/*! start:head.css*/
+	}
+
+	@content
+
+	@if nUiHas('critical') {
+		/*! end:head.css*/
+	}
+}
+
 /// Critical block start
 /// @output A critical block start comment
 @mixin nUiCriticalStart() {


### PR DESCRIPTION
IMHO

````
@include nUiCritical() {
   // some styles
}
```

Is easier to comprehend

````
@include nUiCriticalStart;
   // some styles
@include nUiCriticalEnd;
```

provided `//some styles` doe snot use an `@import`

@i-like-robots 

Although I am wary of increasing the API surface area