### PR TITLE
Make ad loading faster (behind flag)

### DIFF
--- a/ads/index.js
+++ b/ads/index.js
@@ -162,8 +162,12 @@ module.exports = {
 		})
 	},
 	init: function (flags) {
-		window.addEventListener('ftNextLoaded', () => {
+		if(flags && flags.get('adsPrioritiseLoading')) {
 			this.onload(flags);
-		});
+		} else {
+			window.addEventListener('ftNextLoaded', () => {
+				this.onload(flags);
+			});
+		}
 	}
 }


### PR DESCRIPTION
/cc @wheresrhys @ironsidevsquincy @leggsimon 
The faster ads load, the better viewability/potentially impressions.

By not waiting for ftNextLoaded, ads should load ~4-500ms faster. Do this behind a flag so we can set up a speedcurve page and check the impact on other metrics.