### PR TITLE
Generate the page view, then the barrier view

### DIFF
--- a/tracking/js/ft/o-tracking-wrapper.js
+++ b/tracking/js/ft/o-tracking-wrapper.js
@@ -85,7 +85,12 @@ const oTrackingWrapper = {
 
 				let offers = document.querySelectorAll('[data-offer-id]');
 				let acquisitionContext = document.querySelectorAll('[data-acquisition-context]');
+			};
 
+			// FIXME - should not fire on barriers, but needs to be around for a while data analytics fix their SQL
+			oTracking.page(pageViewConf.context);
+
+			if (barrierType) {
 				broadcast('oTracking.event', Object.assign({
 					category: 'barrier',
 					action: 'view',
@@ -95,9 +100,6 @@ const oTrackingWrapper = {
 					offers: nodesToArray(offers).map(e => e.getAttribute('data-offer-id'))
 				}, context))
 			}
-
-			// FIXME - should not fire on barriers, but needs to be around for a while data analytics fix their SQL
-			oTracking.page(pageViewConf.context);
 
 		} catch (err) {
 			broadcast('oErrors.log', {

--- a/tracking/js/ft/o-tracking-wrapper.js
+++ b/tracking/js/ft/o-tracking-wrapper.js
@@ -71,9 +71,14 @@ const oTrackingWrapper = {
 			let productSelectorFlag = document.querySelector('[data-barrier-is-product-selector]');
 
 			if (barrierType) {
-
 				pageViewConf.context.barrier = true;
 				pageViewConf.context.barrierType = barrierType.getAttribute('data-barrier');
+			};
+
+			// FIXME - should not fire on barriers, but needs to be around for a while data analytics fix their SQL
+			oTracking.page(pageViewConf.context);
+
+			if (barrierType) {
 
 				const isProductSelector = (productSelectorFlag) ? productSelectorFlag.getAttribute('data-barrier-is-product-selector') === 'true' : false;
 
@@ -83,14 +88,9 @@ const oTrackingWrapper = {
 					subtype: barrierType.getAttribute('data-barrier')
 				}
 
-				let offers = document.querySelectorAll('[data-offer-id]');
-				let acquisitionContext = document.querySelectorAll('[data-acquisition-context]');
-			};
+				const offers = document.querySelectorAll('[data-offer-id]');
+				const acquisitionContext = document.querySelectorAll('[data-acquisition-context]');
 
-			// FIXME - should not fire on barriers, but needs to be around for a while data analytics fix their SQL
-			oTracking.page(pageViewConf.context);
-
-			if (barrierType) {
 				broadcast('oTracking.event', Object.assign({
 					category: 'barrier',
 					action: 'view',


### PR DESCRIPTION
Allows the barrier event to be attributed to the visit - https://github.com/Financial-Times/o-tracking/issues/131