### PR TITLE
Add enhanced functionality for grouped preferences

### DIFF
--- a/myft/main.scss
+++ b/myft/main.scss
@@ -81,6 +81,7 @@ $_n-ui-myft-is-silent: nUiHas('myft') == false or $_n-ui-myft-applied == true;
 		.n-myft-ui__button {
 			border-radius: 0;
 			margin-left: -5px;
+			transition: all 0.1s ease-in-out;
 		}
 		.n-myft-ui__button:first-of-type {
 			border-bottom-left-radius: 3px;

--- a/myft/templates/prefer-group.html
+++ b/myft/templates/prefer-group.html
@@ -1,5 +1,6 @@
 <form class="n-myft-ui n-myft-ui--prefer-group" method="POST"
 	data-myft-ui="prefer-group"
+	data-preference-name="{{name}}"
 	action="/__myft/api/core/preferred/preference/{{name}}?method=put">
 	<fieldset class="n-myft-ui__fieldset">
 		{{#if legend}}<legend class="n-myft-ui__legend">{{legend}}</legend>{{/if}}
@@ -9,16 +10,20 @@
 	{{#each options}}
 		<button
 			type="submit"
-			class="n-myft-ui__button" aria-pressed="{{#if isSelected}}true{{else}}false{{/if}}"
-			data-trackable="set-{{../name}}-{{name}}"
 			name="_rel.type" value="{{name}}"
+			aria-label="{{text}}"
+			aria-pressed="{{#if isSelected}}true{{else}}false{{/if}}"
+			class="n-myft-ui__button"
+			data-alternate-label="{{text}}"
+			data-trackable="set-{{../name}}-{{name}}"
 		>{{text}}</button>
 	{{/each}}
 		<button
 			type="submit"
-			class="n-myft-ui__button" aria-pressed="{{#if type}}false{{else}}true{{/if}}"
-			data-trackable="set-{{name}}-off"
 			name="method" value="delete"
+			class="n-myft-ui__button" aria-pressed="{{#if type}}false{{else}}true{{/if}}"
+			data-alternate-label="Off"
+			data-trackable="set-{{name}}-off"
 		>Off</button>
 	</fieldset>
 </form>

--- a/myft/templates/prefer-group.html
+++ b/myft/templates/prefer-group.html
@@ -1,5 +1,5 @@
 <form class="n-myft-ui n-myft-ui--prefer-group" method="POST"
-	data-myft-ui="prefer-group"
+	{{#if @root.flags.myFtDigestPrefsEnhanced}}data-myft-ui="prefer"{{/if}}
 	data-preference-name="{{name}}"
 	action="/__myft/api/core/preferred/preference/{{name}}?method=put">
 	<fieldset class="n-myft-ui__fieldset">

--- a/myft/ui-browser.js
+++ b/myft/ui-browser.js
@@ -341,7 +341,7 @@ function getInteractionHandler (myftFeature) {
 	return function (ev, el) {
 		ev.preventDefault();
 
-		const buttonWithValTriggered = !!(el.tagName.toLowerCase() === 'button' && el.name && el.value);
+		const buttonWithValTriggered = !!(flags.get('myFtDigestPrefsEnhanced') && el.tagName.toLowerCase() === 'button' && el.name && el.value);
 		const activeButton = (buttonWithValTriggered) ? el : el.querySelector('button');
 		const form = (buttonWithValTriggered) ? el.closest('form') : el;
 		const formButtons = (buttonWithValTriggered) ? $$('button', form) : [activeButton];
@@ -438,6 +438,7 @@ export function init (opts) {
 		Object.keys(uiSelectors).forEach(myftFeature => {
 			if (myftClient.loaded[`myftFeature.${types[myftFeature]}`]) {
 				results[myftFeature] = myftClient.loaded[`myftFeature.${types[myftFeature]}`];
+
 				updateUiForFeature({
 					myftFeature,
 					subjects: results[myftFeature],
@@ -456,10 +457,12 @@ export function init (opts) {
 			document.body.addEventListener(`myft.${actors[myftFeature]}.${myftFeature}.${types[myftFeature]}.remove`, ev => updateAfterIO(myFtFeatureFromEvent(ev), ev.detail));
 
 			delegate.on('submit', uiSelectors[myftFeature], getInteractionHandler(myftFeature));
-
 		});
 
+		if (flags.get('myFtDigestPrefsEnhanced')) {
 			delegate.on('click', '.n-myft-ui--prefer-group button', getInteractionHandler('preferred'));
+		}
+
 		//copy from list to list
 		delegate.on('click', '[data-myft-ui="copy-to-list"]', ev => {
 			ev.preventDefault();
@@ -484,6 +487,7 @@ export function	updateUi (el, ignoreLinks) {
 		if (!results[myftFeature]) {
 			return;
 		}
+
 		updateUiForFeature({
 			myftFeature,
 			subjects: results[myftFeature],

--- a/myft/ui-browser.js
+++ b/myft/ui-browser.js
@@ -234,7 +234,7 @@ function updateAfterIO (myftFeature, detail) {
 
 	updateUiForFeature({
 		myftFeature,
-		subjects: [detail.subject],
+		subjects: [{ uuid: detail.subject, '_rel': detail.data._rel }],
 		state: !!detail.results
 	});
 
@@ -310,7 +310,7 @@ function onLoad (ev) {
 
 	updateUiForFeature({
 		myftFeature,
-		subjects: results[myftFeature].map(getUuid),
+		subjects: results[myftFeature],
 		state: true
 	});
 }
@@ -423,7 +423,7 @@ export function init (opts) {
 				results[myftFeature] = myftClient.loaded[`myftFeature.${types[myftFeature]}`];
 				updateUiForFeature({
 					myftFeature,
-					subjects: results[myftFeature].map(item => getUuid(item)),
+					subjects: results[myftFeature],
 					state: true
 				});
 
@@ -468,7 +468,7 @@ export function	updateUi (el, ignoreLinks) {
 		}
 		updateUiForFeature({
 			myftFeature,
-			subjects: results[myftFeature].map(item => getUuid(item)),
+			subjects: results[myftFeature],
 			state: true,
 			context: el
 		});

--- a/myft/ui-browser.js
+++ b/myft/ui-browser.js
@@ -78,12 +78,16 @@ function updateUiForFeature (opts) {
 		return;
 	}
 
-	const controls = $$(uiSelectors[opts.myftFeature], opts.context);
+	const featureForms = $$(uiSelectors[opts.myftFeature], opts.context);
 	const idProperty = idProperties[opts.myftFeature];
+	const uuids = opts.subjects.map(getUuid);
 
-	controls.forEach(el => {
-		if (opts.subjects.indexOf(el.getAttribute(idProperty)) > -1) {
-			toggleButton(el.querySelector('button'), opts.state);
+	featureForms.forEach(form => {
+		const index = uuids.indexOf(form.getAttribute(idProperty));
+		if (index > -1) {
+			const type = opts.subjects[index]._rel && opts.subjects[index]._rel.type;
+			const activeMultiButton = form.querySelector(`button[value="${type || 'delete'}"]`);
+			$$('button', form).forEach(button => toggleButton(button, (activeMultiButton) ? button === activeMultiButton : opts.state));
 		}
 	});
 }
@@ -442,6 +446,7 @@ export function init (opts) {
 
 		});
 
+			delegate.on('click', '.n-myft-ui--prefer-group button', getInteractionHandler('preferred'));
 		//copy from list to list
 		delegate.on('click', '[data-myft-ui="copy-to-list"]', ev => {
 			ev.preventDefault();

--- a/myft/ui-browser.js
+++ b/myft/ui-browser.js
@@ -341,24 +341,29 @@ function getInteractionHandler (myftFeature) {
 	return function (ev, el) {
 		ev.preventDefault();
 
-		const button = el.querySelector('button');
-		if (button.hasAttribute('disabled')) {
+		const buttonWithValTriggered = !!(el.tagName.toLowerCase() === 'button' && el.name && el.value);
+		const activeButton = (buttonWithValTriggered) ? el : el.querySelector('button');
+		const form = (buttonWithValTriggered) ? el.closest('form') : el;
+		const formButtons = (buttonWithValTriggered) ? $$('button', form) : [activeButton];
+
+		if (formButtons.some((button) => button.hasAttribute('disabled'))) {
 			return;
 		}
-		button.setAttribute('disabled', '');
 
-		const isPressed = button.getAttribute('aria-pressed') === 'true';
-		const action = isPressed ? 'remove' : 'add';
-		const id = el.getAttribute(idProperties[myftFeature]);
+		formButtons.forEach((button) => button.setAttribute('disabled', ''));
+
+		const isPressed = activeButton.getAttribute('aria-pressed') === 'true';
+		const action = (isPressed || activeButton.value === 'delete') ? 'remove' : 'add';
+		const id = form.getAttribute(idProperties[myftFeature]);
 		const type = types[myftFeature];
 
-		let meta = {};
+		const hiddenFields = $$('input[type="hidden"]', form);
+		const metaFields = (buttonWithValTriggered) ? [activeButton, ...hiddenFields] : hiddenFields;
 
-
-
+		let meta = extractMetaData(metaFields);
 
 		if (~['add', 'remove'].indexOf(action)) {
-			const actorId = el.getAttribute('data-actor-id');
+			const actorId = form.getAttribute('data-actor-id');
 
 			if (type === 'concept') {
 				const conceptIds = id.split(',');

--- a/myft/ui-browser.js
+++ b/myft/ui-browser.js
@@ -319,6 +319,24 @@ function onLoad (ev) {
 	});
 }
 
+// extract properties with _rel. prefix into nested object, as expected by the API for relationship props
+function extractMetaData(inputs) {
+	const meta = {};
+
+	inputs.forEach((input) => {
+		if (input.name.startsWith('_rel.')) {
+			const key = input.name.slice('_rel.'.length);
+			meta._rel = meta._rel || {};
+			meta._rel[key] = input.value;
+
+		} else if (input.type === 'hidden') {
+			meta[input.name] = input.value;
+		}
+	});
+
+	return meta;
+}
+
 function getInteractionHandler (myftFeature) {
 	return function (ev, el) {
 		ev.preventDefault();
@@ -336,18 +354,8 @@ function getInteractionHandler (myftFeature) {
 
 		let meta = {};
 
-		$$('input[type="hidden"]', el).forEach(input => {
 
-			// extract properties with _rel. prefix into nested object, as expected by the API for relationship props
-			if(input.name.startsWith('_rel.')) {
-				const key = input.name.slice('_rel.'.length);
-				meta._rel = meta._rel || {};
-				meta._rel[key] = input.value;
 
-			} else {
-				meta[input.name] = input.value;
-			}
-		});
 
 		if (~['add', 'remove'].indexOf(action)) {
 			const actorId = el.getAttribute('data-actor-id');

--- a/myft/ui-browser.js
+++ b/myft/ui-browser.js
@@ -384,7 +384,7 @@ function getInteractionHandler (myftFeature) {
 				});
 
 				Promise.all(followPromises)
-					.then(() => toggleButton(button, action === 'add'))
+					.then(() => toggleButton(activeButton, action === 'add'))
 					.catch(() => {})
 					.then(() => collectionPending = false)
 


### PR DESCRIPTION
Turn on the `myFtDigestPrefsEnhanced` flag to see changes on the alerts page/product tour.

I *really* want to refactor this whole component…

![prefs](https://cloud.githubusercontent.com/assets/150157/16410828/343f92d6-3d1c-11e6-9b52-d0a4f8ff45d8.gif)
(I clicked a normal on/off toggle in the gif just to prove that still worked)