### PR TITLE
quick fix for n-messages `_preactCompatRendered` issue

### DIFF
--- a/promo-messages/index.js
+++ b/promo-messages/index.js
@@ -1,1 +1,1 @@
-module.exports = require('n-messages');
+//module.exports = require('n-messages'); // FIXME: Commenting this out for now to fix preact issue as it is not currently being used

--- a/promo-messages/main.scss
+++ b/promo-messages/main.scss
@@ -1,19 +1,21 @@
-@include nUiCriticalStart('promoMessages');
-
-$_n-ui-promo-messages-applied: false !default;
-$_n-ui-promo-messages-is-silent: nUiHas('promoMessages') == false or $_n-ui-promo-messages-applied == true;
-$n-messages-is-silent: $_n-ui-promo-messages-is-silent;
-
-@import 'n-messages/main';
-
-@if $_n-ui-promo-messages-is-silent == false {
-	body .o-overlay,
-	body .o-overlay-shadow {
-		@include nUtilZIndexFor(overlay);
-	}
-
-	$_n-ui-promo-messages-applied: true !global;
-	$n-messages-is-silent: true !global;
-}
-
-@include nUiCriticalEnd('promoMessages');
+// FIXME: Commenting this out for now as a the messages in n-messages is not currently being used at the moment
+// Will uncomment it once n-message-prompts is moved over to n-messages
+//@include nUiCriticalStart('promoMessages');
+//
+//$_n-ui-promo-messages-applied: false !default;
+//$_n-ui-promo-messages-is-silent: nUiHas('promoMessages') == false or $_n-ui-promo-messages-applied == true;
+//$n-messages-is-silent: $_n-ui-promo-messages-is-silent;
+//
+//@import 'n-messages/main';
+//
+//@if $_n-ui-promo-messages-is-silent == false {
+//	body .o-overlay,
+//	body .o-overlay-shadow {
+//		@include nUtilZIndexFor(overlay);
+//	}
+//
+//	$_n-ui-promo-messages-applied: true !global;
+//	$n-messages-is-silent: true !global;
+//}
+//
+//@include nUiCriticalEnd('promoMessages');


### PR DESCRIPTION
cc/ @ironsidevsquincy @i-like-robots @wheresrhys 

Guys this is just a quick fix to solve the current `_preactCompatRendered` issue within `n-messages`. I'm just commenting it out for now as the promo messages `n-messages` are not currently being used.