### PR TITLE
Update follow-email to work with the new digest

### DIFF
--- a/myft/js/follow-email.js
+++ b/myft/js/follow-email.js
@@ -7,14 +7,14 @@ let _overlayForm;
 
 //FIXME: remove this and make myFtClient.loaded update after client-side changes
 let prefs = {
-	subscribedToDaily: null,
+	subscribedToDigest: null,
 	userDismissed: null
 };
 
 function setInitialPrefs () {
 	const allLoadedPrefs = _myFtClient.loaded['preferred.preference'].items;
 
-	prefs.subscribedToDaily = allLoadedPrefs.find(pref => pref.uuid === 'email-daily-digest');
+	prefs.subscribedToDigest = allLoadedPrefs.find(pref => pref.uuid === 'email-digest');
 	prefs.userDismissed = allLoadedPrefs.find(pref => pref.uuid === 'follow-email-dismissed');
 }
 

--- a/myft/js/set-follow-preferences.js
+++ b/myft/js/set-follow-preferences.js
@@ -1,11 +1,15 @@
 const myFtApi = require('next-myft-client');
+const relData = {
+	timezone: 'Europe/London',
+	type: 'daily'
+};
 
 function addPref (uuid, userId) {
 	//TODO: align client/server-side methods in client
 	if (typeof myFtApi.addRelationship === 'function') {
-		return myFtApi.addRelationship('user', userId, 'preferred', 'preference', { uuid });
+		return myFtApi.addRelationship('user', userId, 'preferred', 'preference', { uuid, '_rel': relData });
 	} else {
-		return myFtApi.add('user', userId, 'preferred', 'preference', uuid, { uuid });
+		return myFtApi.add('user', userId, 'preferred', 'preference', uuid, { '_rel': relData });
 	}
 }
 
@@ -14,7 +18,7 @@ module.exports = (userId, method, userDismissed) => {
 	let dismissPrefPromise = Promise.resolve();
 
 	if (method === 'put') {
-		emailPrefPromise = addPref('email-daily-digest', userId);
+		emailPrefPromise = addPref('email-digest', userId);
 	}
 
 	if (userDismissed) {

--- a/myft/templates/follow-email.html
+++ b/myft/templates/follow-email.html
@@ -3,7 +3,7 @@
 
 	<p class="myft-follow__text">You’re now following this topic.</p>
 
-{{#ifAll notSubscribedToDaily notYetDismissed}}
+{{#ifAll notSubscribedToDigest notYetDismissed}}
 	<form method="POST" action="/__myft/api/core/follow-email/set-preferences" class="myft-follow__form js-follow-email-form">
 		<p class="myft-follow__text">Get headlines in a daily email on topics you follow.</p>
 

--- a/myft/ui-browser.js
+++ b/myft/ui-browser.js
@@ -248,7 +248,7 @@ function updateAfterIO (myftFeature, detail) {
 		case 'followed':
 			if (flags.get('myFtFollowEmail') && detail.results && !collectionPending) {
 
-				if (!followEmail.prefs.subscribedToDaily && !followEmail.prefs.userDismissed && detail.data.name) {
+				if (!followEmail.prefs.subscribedToDigest && !followEmail.prefs.userDismissed && detail.data.name) {
 
 					return myftClient.personaliseUrl(`/myft/api/onsite/follow-email/form?fragment=true&name=${encodeURIComponent(detail.data.name)}`)
 						.then(url => fetch(url, { credentials: 'same-origin' }))
@@ -281,8 +281,8 @@ function updateAfterIO (myftFeature, detail) {
 			break;
 		case 'preferred':
 			//FIXME: remove this and make myFtClient.loaded update after client-side changes
-			if (detail.subject === 'email-daily-digest') {
-				followEmail.prefs.subscribedToDaily = true;
+			if (detail.subject === 'email-digest') {
+				followEmail.prefs.subscribedToDigest = true;
 			} else if (detail.subject === 'follow-email-dismissed') {
 				followEmail.prefs.userDismissed = true;
 			}


### PR DESCRIPTION
Updates the follow+email overlay to reflect changes to the email digest preference model.

Also sneaks in the missing timezone data when setting the preference (which is just hard-coded for now, like the prefs page).