### PR TITLE
Add preconnect for GPT libraries, and refactor ads init

### DIFF
--- a/ads/index.js
+++ b/ads/index.js
@@ -111,7 +111,7 @@ function onAdsComplete (flags, event) {
 }
 
 module.exports = {
-	onload: flags => {
+	init: flags => {
 		return Promise.resolve()
 			.then(() => {
 				if (flags && flags.get('ads')) {
@@ -144,14 +144,5 @@ module.exports = {
 				}
 
 		})
-	},
-	init: function (flags) {
-		if(flags && flags.get('adsPrioritiseLoading')) {
-			this.onload(flags);
-		} else {
-			window.addEventListener('ftNextLoaded', () => {
-				this.onload(flags);
-			});
-		}
 	}
 }

--- a/ads/test/index.spec.js
+++ b/ads/test/index.spec.js
@@ -23,7 +23,7 @@ describe('Main', () => {
 	it('Should init if flag is set to true and appname given', () => {
 		const flags = { get: () => true };
 		const initSpy = sandbox.stub(ads, 'init', () => ({ slots: { initSlot: sinon.stub()}, config: sinon.stub() }));
-		return main.onload(flags).then(() => {
+		return main.init(flags).then(() => {
 			expect(initSpy).to.have.been.called;
 		});
 	});
@@ -33,7 +33,7 @@ describe('Main', () => {
 		sandbox.stub(utils, 'getAppName', () => false );
 		const initSpy = sandbox.stub(ads, 'init', () => ({ slots: { initSlot: sinon.stub() }}));
 		sandbox.stub(ads.slots, 'initSlot');
-		return main.onload(flags).then(() => {
+		return main.init(flags).then(() => {
 			expect(initSpy).not.to.have.been.called;
 		});
 	});
@@ -42,7 +42,7 @@ describe('Main', () => {
 		const flags = { get: () => true };
 		const adInit = sandbox.spy(ads.slots, 'initSlot');
 		sandbox.stub(ads, 'init', () => ({slots: { initSlot: adInit }, config: sinon.stub }));
-		return main.onload(flags).then(() => {
+		return main.init(flags).then(() => {
 			expect(adInit).to.have.been.called;
 		});
 	});
@@ -56,7 +56,7 @@ describe('Main', () => {
 		};
 		const perfMark = sandbox.stub(window.performance, 'mark', () => true );
 		const info = sandbox.stub(utils.log, 'info');
-		main.onload(flags)
+		main.init(flags)
 			.then(() =>{
 				document.addEventListener('oAdsLogTestDone', () => {
 					expect(info).to.have.been.calledWith('Ad loaded in slot');
@@ -83,7 +83,7 @@ describe('Main', () => {
 		sandbox.stub(document, 'querySelector', () => ({getAttribute: () => fakeArticleUuid}));
 		const fetchSpy = sandbox.stub(jsonpFetch, 'default', () => Promise.reject() );
 
-		return main.onload(flags).then(() => {
+		return main.init(flags).then(() => {
 			expect(fetchSpy).to.have.been.calledWith('https://ads-api.ft.com/v1/content/' + fakeArticleUuid + '?referrer=https%3A%2F%2Ftest-referrer.com%2Fpath');
 			expect(ads.config().gpt.unitName).to.equal('5887/ft.com/' + fakeDfpSiteAndZone + '/' + fakeDfpSiteAndZone);
 		});
@@ -100,7 +100,7 @@ describe('Main', () => {
 		sandbox.stub(document, 'querySelector', () => ({getAttribute: () => fakeArticleUuid}));
 		const fetchSpy = sandbox.stub(jsonpFetch, 'default', () => Promise.reject() );
 
-		return main.onload(flags).then(() => {
+		return main.init(flags).then(() => {
 			expect(fetchSpy).to.have.been.calledWith('https://ads-api.ft.com/v1/content/' + fakeArticleUuid);
 			expect(ads.config().gpt.unitName).to.equal('5887/ft.com/' + fakeDfpSiteAndZone + '/' + fakeDfpSiteAndZone);
 		});
@@ -118,7 +118,7 @@ describe('Main', () => {
 		sandbox.stub(document, 'querySelector', () => ({getAttribute: () => fakeArticleUuid}));
 		const fetchSpy = sandbox.stub(jsonpFetch, 'default', () => Promise.reject() );
 
-		return main.onload(flags).then(() => {
+		return main.init(flags).then(() => {
 			expect(fetchSpy).to.have.been.calledWith('https://ads-api.ft.com/v1/content/' + fakeArticleUuid);
 			expect(ads.config().gpt.unitName).to.equal('5887/ft.com/unclassified');
 		});
@@ -148,7 +148,7 @@ describe('Main', () => {
 			});
 		});
 
-		return main.onload(flags).then(() => {
+		return main.init(flags).then(() => {
 			expect(fetchSpy).to.have.been.calledWith('https://ads-api.ft.com/v1/content/' + fakeArticleUuid);
 			expect(ads.config().gpt.unitName).to.equal('5887/ft.com/successful-site/successful-zone');
 			expect(ads.config().krux.id).to.be.ok;
@@ -177,7 +177,7 @@ describe('Main', () => {
 			});
 		});
 
-		return main.onload(flags).then(() => {
+		return main.init(flags).then(() => {
 			expect(fetchSpy).to.have.been.calledWith('https://ads-api.ft.com/v1/concept/' + fakeConceptId);
 			expect(ads.config().gpt.unitName).to.equal('5887/ft.com/successful-site/successful-zone');
 			expect(ads.config().krux.id).to.be.ok;
@@ -204,7 +204,7 @@ describe('Main', () => {
 			});
 		});
 
-		return main.onload(flags).then(() => {
+		return main.init(flags).then(() => {
 			expect(fetchSpy).to.have.been.calledWith('https://ads-api.ft.com/v1/user');
 		});
 	});
@@ -216,7 +216,7 @@ describe('Main', () => {
 		sandbox.stub(document, 'querySelector', () => ({getAttribute: () => '12345'}));
 		const fetchSpy = sandbox.stub(window, 'fetch');
 
-		return main.onload(flags).then(() => {
+		return main.init(flags).then(() => {
 			expect(fetchSpy).not.to.have.been.calledWith('https://ads-api.ft.com/v1/user');
 		});
 	});
@@ -246,7 +246,7 @@ describe('Main', () => {
 			});
 		});
 
-		return main.onload(flags).then(() => {
+		return main.init(flags).then(() => {
 			expect(fetchSpy).to.have.been.calledWith('/__ads-api/v1/user');
 			Object.defineProperty(XMLHttpRequest.prototype, 'withCredentials', {
 				configurable: true, // defaults to false

--- a/layout/wrapper.html
+++ b/layout/wrapper.html
@@ -16,12 +16,21 @@
 		<link rel="preconnect" href="https://next-geebee.ft.com">
 		<link rel="preconnect" href="https://spoor-api.ft.com">
 		<link rel="preconnect" href="https://session-next.ft.com" crossorigin="use-credentials">
-		{{#if @root.flags.adsPrioritiseLoading }}
+
+		{{#ifEquals @root.flags.adsPreconnect 'preconnect' }}
 			<link rel="preconnect" href="https://ads-api.ft.com">
 			<link rel="preconnect" href="https://www.googletagservices.com">
 			<link rel="preconnect" href="https://partner.googleadservices.com">
 			<link rel="preconnect" href="https://securepubads.g.doubleclick.net">
-		{{/if}}
+		{{/ifEquals}}
+
+		{{#ifEquals @root.flags.adsPreconnect 'dns' }}
+			<link rel="dns-prefetch" href="https://ads-api.ft.com">
+			<link rel="dns-prefetch" href="https://www.googletagservices.com">
+			<link rel="dns-prefetch" href="https://partner.googleadservices.com">
+			<link rel="dns-prefetch" href="https://securepubads.g.doubleclick.net">
+		{{/ifEquals}}
+
 		{{#each preconnect}}
 		<link rel="preconnect" href="{{host}}"{{#if crossorigin}} crossorigin="{{crossorigin}}"{{/if}}>
 		{{/each}}

--- a/layout/wrapper.html
+++ b/layout/wrapper.html
@@ -14,9 +14,14 @@
 		<link rel="dns-prefetch" href="{{this}}">
 		{{/each}}
 		<link rel="preconnect" href="https://next-geebee.ft.com">
-		<link rel="preconnect" href="https://ads-api.ft.com">
 		<link rel="preconnect" href="https://spoor-api.ft.com">
 		<link rel="preconnect" href="https://next-session.ft.com" crossorigin="use-credentials">
+		{{#if @root.flags.adsPrioritiseLoading }}
+			<link rel="preconnect" href="https://ads-api.ft.com">
+			<link rel="preconnect" href="https://www.googletagservices.com">
+			<link rel="preconnect" href="https://partner.googleadservices.com">
+			<link rel="preconnect" href="https://securepubads.g.doubleclick.net">
+		{{/if}}
 		{{#each preconnect}}
 		<link rel="preconnect" href="{{host}}"{{#if crossorigin}} crossorigin="{{crossorigin}}"{{/if}}>
 		{{/each}}


### PR DESCRIPTION
/cc @wheresrhys @ironsidevsquincy @andrewgeorgiou1981 @VladDubrovskis 
* Deflagify the ads init change (to not wait for ftNextLoaded)
* Add a bunch of preconnect headers for Ad domains (behind flag, so that we can check the impact on webpagetest).