### PR TITLE
Collapse before - fixes weird jumping bug on articles

### DIFF
--- a/ads/js/oAdsConfig.js
+++ b/ads/js/oAdsConfig.js
@@ -67,7 +67,7 @@ module.exports = function (flags, contextData, userData) {
 			unitName:	gptUnitName
 		},
 		krux: kruxConfig,
-		collapseEmpty: 'after',
+		collapseEmpty: 'before',
 		dfp_targeting: utils.keyValueString(targeting)
 	};
 


### PR DESCRIPTION
/cc @andrewgeorgiou1981 @VladDubrovskis @ironsidevsquincy 
With collapse: after, DFP loads an iframe of height 250 before the ad call, which pushes some of the content down and up again.
