### PR TITLE
Set: o-expander 'is-silent' value to false

### DIFF
--- a/expander/main.scss
+++ b/expander/main.scss
@@ -1,6 +1,6 @@
 @include nUiCriticalStart('expander');
 
-$o-expander-is-silent: nUiHas('expander') !default;
+$o-expander-is-silent: not nUiHas('expander') !default;
 
 @import 'o-expander/main';
 


### PR DESCRIPTION
cc @i-like-robots @keirog 

Looking at this [PR](https://github.com/Financial-Times/n-ui/commit/b8a9ee320c499ced6125bae5a404dbd456cef4a7#diff-02637b46ebfc732031e2457081a8bba7), seems most components have `is-silent` state set to `false` (by prefacing `nUiHas` with `not`), but not `expander` (changed here), and also [`drawer`](https://github.com/Financial-Times/n-ui/blob/1e67440427a27da664f8d9fde10710ec3de4ab5c/drawer/main.scss#L4) (using `header` as its `nUiHas` argument), although that is still working fine.

#### Search results page
##### From:
![screen shot 2016-07-08 at 11 35 57](https://cloud.githubusercontent.com/assets/10484515/16685119/c0b57c26-4500-11e6-9c30-d305fb327688.png)

##### To (w/ toggle functionality reinstated):
![screen shot 2016-07-08 at 11 36 07](https://cloud.githubusercontent.com/assets/10484515/16685111/b83a9234-4500-11e6-992e-929872ba2521.png)
