### PR TITLE
Remove `o-header` and `awesomplete` resolutions

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -47,9 +47,5 @@
     "superstore": "^2.1.0",
     "superstore-sync": "^2.1.0",
     "o-tracking": "^1.1.8"
-  },
-  "resolutions": {
-    "o-header": "^6.0.3",
-    "awesomplete": "^1.1.1"
   }
 }


### PR DESCRIPTION
`n-ui` should be the only thing requiring `o-header` in next now so we _shouldn't_ need these resolutions.

cc/ @i-like-robots @wheresrhys 