### PR TITLE
replace deprecation-warning n* with deprecation-happy o*

### DIFF
--- a/myft/main.scss
+++ b/myft/main.scss
@@ -15,19 +15,19 @@
 	}
 
 	.n-myft-ui__button {
-		@include nButtons();
+		@include oButtons();
 	}
 
 	.n-myft-ui__button--inverse {
-		@include nButtonsTheme(inverse);
+		@include oButtonsTheme(inverse);
 	}
 
 	.n-myft-ui__button--medium {
-		@include nButtonsSize(medium);
+		@include oButtonsSize(medium);
 	}
 
 	.n-myft-ui__button--big {
-		@include nButtonsSize(big);
+		@include oButtonsSize(big);
 	}
 
 	.n-myft-ui--follow {
@@ -140,7 +140,7 @@
 	}
 
 	.no-js .myft-ui--prefer button {
-		@include nButtons();
+		@include oButtons();
 		margin-left: 10px;
 	}
 

--- a/myft/scss/_follow-email.scss
+++ b/myft/scss/_follow-email.scss
@@ -23,8 +23,7 @@
 	}
 
 	.myft-follow__btn {
-		//TODO: switch myft-ui buttons to o-buttons
-		@include nButtons($size: big);
+		@include oButtons($size: big);
 		margin: $spacing-unit 0 0 $spacing-unit;
 	}
 
@@ -33,7 +32,7 @@
 	}
 
 	.myft-follow__btn--standout {
-		@include nButtonsTheme(standout);
+		@include oButtonsTheme(standout);
 	}
 
 	@include oGridRespondTo($until: S) {

--- a/welcome-message/new/main.scss
+++ b/welcome-message/new/main.scss
@@ -86,7 +86,7 @@
 	}
 
 	.n-welcome-message__button {
-		@include nButtons($theme:'standout');
+		@include oButtons($theme:'standout');
 		margin-left: 12px;
 		white-space: nowrap;
 

--- a/welcome-message/old/main.scss
+++ b/welcome-message/old/main.scss
@@ -99,14 +99,14 @@
 	}
 
 	.n-welcome__btn {
-		@include nButtons($theme: inverse);
+		@include oButtons($theme: inverse);
 
 		@include oGridRespondTo(M) {
-			@include nButtonsSize(big);
+			@include oButtonsSize(big);
 		}
 
 		&--standout {
-			@include nButtons($theme: standout);
+			@include oButtons($theme: standout);
 		}
 	}
 


### PR DESCRIPTION
Hi there,

The build log for `next-stream-page` has over time got very large, mainly because of deprecation warnings. I thought I'd spend 5 minutes looking at this, and making a start with this PR.

Really the main reason for this is for me to better understand whether:
a) we can replace `n-button` with `o-button` now?
b) how'd I ensure that any changes to `n-ui` won't have an adverse effect on an app somewhere, such as `myFT` - would I need to setup and run all apps that use `n-ui` & test that they're all looking ok? (Although I'm not sure this is what `n-ui` contributors do?)