### PR TITLE
Fixes the rendering of images when using ie10 in ie7 comp mode

### DIFF
--- a/js-setup/templates/bootstrapper.html
+++ b/js-setup/templates/bootstrapper.html
@@ -43,11 +43,11 @@
 			{{/if}}
 
 			ftNextLoadScript(polyfillUrl + '?callback=' + polyfillCallbackName + '{{#if @root.flags.polyfillsRUM}}&rum=1{{/if}}&features=' + [
-				'default',
+				'default|gated',
 				'requestAnimationFrame',
 				'Promise',
 				'matchMedia',
-				'HTMLPictureElement',
+				'HTMLPictureElement|gated',
 				// the following polyfills are included pending https://github.com/Financial-Times/polyfill-service/issues/653
 				'CustomEvent|always|gated',
 				'fetch|always|gated',


### PR DESCRIPTION
- Editorial use methode to preview article content before publish
- The preview webview is using ie10 in ie7 compatibility mode
- These changes to how we call the polyfill service allow images
  to render correctly
- This is due to HTMLPictureElement polyfill
