### PR TITLE
pass meganav section name to beacon

### DIFF
--- a/header/partials/meganav/template.html
+++ b/header/partials/meganav/template.html
@@ -1,7 +1,7 @@
 {{#if meganav}}
-<div class="o-header__mega" id="o-header-mega-{{@index}}" role="group" aria-labelledby="o-header-link-{{@index}}" data-o-header-mega data-trackable="meganav">
+<div class="o-header__mega" id="o-header-mega-{{@index}}" role="group" aria-labelledby="o-header-link-{{@index}}" data-o-header-mega data-trackable="meganav | {{name}}">
 	<div class="o-header__container">
-		<div class="o-header__mega-wrapper" data-trackable="{{name}}">
+		<div class="o-header__mega-wrapper">
 		{{#each meganav}}
 		{{#if data}}
 		{{{usePartial component path='n-ui/header/partials/meganav'}}}

--- a/header/partials/meganav/template.html
+++ b/header/partials/meganav/template.html
@@ -1,7 +1,7 @@
 {{#if meganav}}
 <div class="o-header__mega" id="o-header-mega-{{@index}}" role="group" aria-labelledby="o-header-link-{{@index}}" data-o-header-mega data-trackable="meganav">
 	<div class="o-header__container">
-		<div class="o-header__mega-wrapper">
+		<div class="o-header__mega-wrapper" data-trackable="{{name}}">
 		{{#each meganav}}
 		{{#if data}}
 		{{{usePartial component path='n-ui/header/partials/meganav'}}}


### PR DESCRIPTION
@i-like-robots 

Passes through the section name to be trackable.

Current: 
![screenshot 2016-07-26 11 03 54](https://cloud.githubusercontent.com/assets/11544418/17134098/b6da1fd0-5320-11e6-98f0-f5c8ae340d36.png)

Now: 
![screenshot 2016-07-26 11 03 18](https://cloud.githubusercontent.com/assets/11544418/17134109/ca2df89a-5320-11e6-880d-10269fb156c7.png)
