### PR TITLE
Fix z index order

### DIFF
--- a/utils/_mixins.scss
+++ b/utils/_mixins.scss
@@ -9,9 +9,9 @@ $n-ui-z-index-basis: 100;
 /// Ordered list of z-indexes use cases
 /// @type List
 $n-ui-z-index-order: (
-	'typeahead',
 	'banner',
 	'meganav',
+	'typeahead',
 	'sticky-header',
 	'drawer',
 	'welcome',

--- a/utils/_mixins.scss
+++ b/utils/_mixins.scss
@@ -9,11 +9,8 @@ $n-ui-z-index-basis: 100;
 /// Ordered list of z-indexes use cases
 /// @type List
 $n-ui-z-index-order: (
-	'banner',
 	'meganav',
 	'typeahead',
-	'sticky-header',
-	'drawer',
 	'welcome',
 	'overlay',
 	'notification'


### PR DESCRIPTION
@i-like-robots @keirog 

Puts `typeahead` above `meganav` so it doesn't hide behind the meganav when this happens

![screenshot 2016-07-26 14 51 29](https://cloud.githubusercontent.com/assets/11544418/17140781/96ab70bc-5341-11e6-9630-f67ba99088a1.png)

And removes `banner`, `sticky-header`, `drawer` use-cases as they are unused.

(related to https://github.com/Financial-Times/n-ui/pull/295)