### PR TITLE
Rhys/cors proxy support

### DIFF
--- a/ads/index.js
+++ b/ads/index.js
@@ -18,7 +18,7 @@ const customTimings = {};
 function getContextualTargetingPromise (appName) {
 	let uuid;
 	let url;
-	const apiUrlRoot = ('withCredentials' in new XMLHttpRequest()) ? 'https://ads-api.ft.com/v1/' : '/__ads-api/v1/';
+	const apiUrlRoot = 'https://ads-api.ft.com/v1/';
 	if (appName === 'article') {
 		uuid = document.querySelector('[data-content-id]').getAttribute('data-content-id');
 
@@ -32,16 +32,20 @@ function getContextualTargetingPromise (appName) {
 		url = `${apiUrlRoot}concept/${uuid}`;
 	}
 
-	return (uuid && url) ? fetch(url, { timeout: 2000 })
+	return (uuid && url) ? fetch(url, {
+		timeout: 2000,
+		useCorsProxy: true
+	})
 			.then(res => res.json())
 			.catch(() => ({})) : Promise.resolve({});
 };
 
 function getUserTargetingPromise () {
-	const apiUrlRoot = ('withCredentials' in new XMLHttpRequest()) ? 'https://ads-api.ft.com/v1/' : '/__ads-api/v1/';
+	const apiUrlRoot = 'https://ads-api.ft.com/v1/';
 	return fetch(`${apiUrlRoot}user`, {
 		credentials: 'include',
-		timeout: 2000
+		timeout: 2000,
+		useCorsProxy: true
 	})
 		.then(res => res.json())
 		.catch(() => ({}));

--- a/js-setup/js/instrument-fetch.js
+++ b/js-setup/js/instrument-fetch.js
@@ -1,5 +1,5 @@
 let theFetch;
-export default function (flags) {
+export default function (flags, oErrors) {
 	theFetch = theFetch || window.fetch;
 	// allow use of our proxy for apis when cors not available
 	if (!('withCredentials' in new XMLHttpRequest())) {

--- a/js-setup/js/instrument-fetch.js
+++ b/js-setup/js/instrument-fetch.js
@@ -1,0 +1,37 @@
+let theFetch;
+export default function (flags) {
+	theFetch = theFetch || window.fetch;
+	// allow use of our proxy for apis when cors not available
+	if (!('withCredentials' in new XMLHttpRequest())) {
+		const realFetch = window.fetch;
+
+		window.fetch = function (url, opts) {
+			if (opts.useCorsProxy) {
+				const urlObj = new URL(url);
+				opts.headers = opts.headers || {};
+				opts.headers['api-host'] = urlObj.origin;
+				url = url.replace(urlObj.origin, '/__api-proxy')
+			}
+			return realFetch.call(this, url, opts)
+		};
+	}
+
+	// turn on more detailed error reporting of ajax calls
+	if (flags.get('clientAjaxErrorReporting')) {
+		const realFetch = window.fetch;
+		window.fetch = function (url, opts) {
+			return realFetch.call(this, url, opts)
+				.catch(function (err) {
+					oErrors.log(url + (opts ? JSON.stringify(opts) : '' ) + err);
+					throw err;
+				});
+		};
+	}
+
+}
+
+export function restore () {
+	if (theFetch) {
+		window.fetch = theFetch;
+	}
+}

--- a/js-setup/js/loader.js
+++ b/js-setup/js/loader.js
@@ -61,7 +61,8 @@ class JsSetup {
 			errorBuffer: window.errorBuffer || []
 		});
 
-		instrumentFetch(flags);
+		instrumentFetch(flags, oErrors);
+
 		if (flags.get('clientAjaxErrorReporting')) {
 
 			const realFetch = window.fetch;

--- a/js-setup/js/loader.js
+++ b/js-setup/js/loader.js
@@ -9,7 +9,7 @@ if (!window.console) {
 
 import {load as loadFonts} from '../../typography/font-loader';
 import {loadScript, waitForCondition, perfMark} from '../../utils';
-
+import instrumentFetch from './instrument-fetch';
 const oErrors = require('o-errors');
 
 // Dispatch a custom `ftNextLoaded` event after the app executes.
@@ -31,6 +31,7 @@ function dispatchLoadedEvent () {
 class JsSetup {
 
 	init () {
+
 		loadFonts(document.documentElement)
 
 		this.appInfo = {
@@ -60,6 +61,7 @@ class JsSetup {
 			errorBuffer: window.errorBuffer || []
 		});
 
+		instrumentFetch(flags);
 		if (flags.get('clientAjaxErrorReporting')) {
 
 			const realFetch = window.fetch;

--- a/js-setup/test/instrument-fetch.spec.js
+++ b/js-setup/test/instrument-fetch.spec.js
@@ -1,0 +1,40 @@
+import instrumentFetch from '../js/instrument-fetch';
+import {restore as restoreFetch} from '../js/instrument-fetch';
+import fetchMock from 'fetch-mock';
+describe('instrument fetch', () => {
+
+	it('should not enable cors proxy where cors supported', () => {
+		const theFetch = window.fetch;
+		instrumentFetch({get: () => null});
+		expect(window.fetch).to.equal(theFetch);
+	})
+
+	it('should enable cors proxy where cors not supported', () => {
+		const theXHR = window.XMLHttpRequest;
+		window.XMLHttpRequest = function () {
+			return {};
+		}
+		fetchMock
+			.mock('/__api-proxy/a-test-url?q=yes', 200);
+		const theFetch = window.fetch;
+		instrumentFetch({get: () => null});
+		expect(window.fetch).not.to.equal(theFetch);
+
+		fetch('https://my.api.com/a-test-url?q=yes', {
+			headers: {
+				a: 'header'
+			},
+			useCorsProxy: true
+		})
+		expect(fetchMock.lastCall()[0]).to.equal('/__api-proxy/a-test-url?q=yes');
+		expect(fetchMock.lastCall()[1].headers).to.deep.equal({
+			a: 'header',
+			'api-host': 'https://my.api.com'
+		});
+		fetchMock.restore();
+		window.XMLHttpRequest = theXHR;
+		restoreFetch();
+	})
+
+
+})

--- a/js-setup/test/instrument-fetch.spec.js
+++ b/js-setup/test/instrument-fetch.spec.js
@@ -1,3 +1,4 @@
+/*global describe,it,expect*/
 import instrumentFetch from '../js/instrument-fetch';
 import {restore as restoreFetch} from '../js/instrument-fetch';
 import fetchMock from 'fetch-mock';


### PR DESCRIPTION
Sister PR for https://github.com/Financial-Times/next-router/pull/33

@adgad this aims to generalise the jsonp-less approach you have for ads API. Can you point me to anything I would need to remove that's in place for ads only