### PR TITLE
Remove samsung as unsupported

### DIFF
--- a/js-setup/templates/ctm.html
+++ b/js-setup/templates/ctm.html
@@ -3,34 +3,7 @@
 	var classes = document.documentElement.className;
 	classes = classes.replace(/\bno-js\b/, 'js');
 
-	// HACK: make the following browsers core as they're unsupported by the polyfill service
-	var isSupported = true;
-
-	{{#if @root.flags.forceCoreExperience}}
-
-	// Add any browsers we want to force core experience upon here by adding to
-	// a property to the `unsupported` object. E.g
-
-	// var unsupported = {
-	//	'Samsung frankenchromium': function (ua) {
-	//		var android = /Android/.test(ua);
-	//		var samsung = /SamsungBrowser/.test(ua);
-	//		return android && samsung;
-	//	}
-	// }
-
-	var unsupported = {};
-
-
-	for (var browser in unsupported) {
-		if (unsupported[browser](navigator.userAgent)) {
-			isSupported = false;
-			break;
-		}
-	}
-	{{/if}}
-
-	window.cutsTheMustard = isSupported && (typeof Function.prototype.bind !== 'undefined');
+	window.cutsTheMustard = (typeof Function.prototype.bind !== 'undefined');
 
 	if (window.cutsTheMustard) {
 		classes = classes.replace(/\bcore\b/, 'enhanced');

--- a/js-setup/templates/ctm.html
+++ b/js-setup/templates/ctm.html
@@ -7,13 +7,19 @@
 	var isSupported = true;
 
 	{{#if @root.flags.forceCoreExperience}}
-	var unsupported = {
-		'Samsung frankenchromium': function (ua) {
-			var android = /Android/.test(ua);
-			var samsung = /SamsungBrowser/.test(ua);
-			return android && samsung;
-		}
-	};
+
+	// Add any browsers we want to force core experience upon here by adding to
+	// a property to the `unsupported` object. E.g
+
+	// var unsupported = {
+	//	'Samsung frankenchromium': function (ua) {
+	//		var android = /Android/.test(ua);
+	//		var samsung = /SamsungBrowser/.test(ua);
+	//		return android && samsung;
+	//	}
+	// }
+
+	var unsupported = {};
 
 
 	for (var browser in unsupported) {

--- a/js-setup/templates/ctm.html
+++ b/js-setup/templates/ctm.html
@@ -3,7 +3,23 @@
 	var classes = document.documentElement.className;
 	classes = classes.replace(/\bno-js\b/, 'js');
 
-	window.cutsTheMustard = (typeof Function.prototype.bind !== 'undefined');
+	// HACK: make the following browsers core as they're unsupported by the polyfill service
+	var isSupported = true;
+
+	{{#if @root.flags.forceCoreExperience}}
+
+	var unsupported = {};
+
+
+	for (var browser in unsupported) {
+		if (unsupported[browser](navigator.userAgent)) {
+			isSupported = false;
+			break;
+		}
+	}
+	{{/if}}
+
+	window.cutsTheMustard = isSupported && (typeof Function.prototype.bind !== 'undefined');
 
 	if (window.cutsTheMustard) {
 		classes = classes.replace(/\bcore\b/, 'enhanced');


### PR DESCRIPTION
Now that the polyfill-service is polyfilling unknown browsers this should fix https://jira.ft.com/browse/NFT-518

@wheresrhys @bjfletcher 