### PR TITLE
align prefgroup with floats not inline-block

### DIFF
--- a/myft/scss/_preference.scss
+++ b/myft/scss/_preference.scss
@@ -117,14 +117,18 @@
 		}
 
 		.n-myft-ui__button {
+			@include clearfix();
 			border-radius: 0;
-			margin-left: -5px;
+			float: left;
+			display: block;
+			margin-left: -1px;
 			transition: all 0.1s ease-in-out;
 		}
 		.n-myft-ui__button:first-of-type {
 			border-bottom-left-radius: 3px;
 			border-left-width: 1px;
 			border-top-left-radius: 3px;
+			margin: 0;
 		}
 
 		.n-myft-ui__button:last-child {

--- a/utils/_mixins.scss
+++ b/utils/_mixins.scss
@@ -35,3 +35,17 @@ $n-ui-z-index-order: (
 		@warn 'z-index for use case "#{$use-case}" not found.';
 	}
 }
+
+@mixin clearfix() {
+	&:before,
+	&:after {
+		content: " ";
+		display: table;
+	}
+
+	&:after {
+		clear: both;
+	}
+
+	*zoom: 1;
+}

--- a/utils/main.scss
+++ b/utils/main.scss
@@ -8,17 +8,7 @@
 	// Layout
 	//
 	.n-util-clearfix {
-		&:before,
-		&:after {
-			content: " ";
-			display: table;
-		}
-
-		&:after {
-			clear: both;
-		}
-
-		*zoom: 1;
+		@include clearfix();
 	}
 
 	//


### PR DESCRIPTION
@keirog 

This is to get around the problem caused by the following facts:

- For the display inline block and margin -5px approach, there needs to be whitespace in between the components
- React strips whitespace from around components, and the solution is to insert some whitespace and wrap the whole thing in a span [for example](https://github.com/Financial-Times/next-myft-page/blob/2c88d7ce76ddddebfc1ca75a305666f5dcf80f6b/shared/components/alerts/preferences/prefer-group.js#L15-L29)
- The pref group styling requires the buttons to not be nested in spans