### PR TITLE
Add full page location as a referrer param on the opt-out link

### DIFF
--- a/opt-out/index.js
+++ b/opt-out/index.js
@@ -18,6 +18,10 @@ function showAndroidLink () {
 }
 
 function init () {
+	$$('.js-optout-link').forEach(a => {
+		const referrer = encodeURIComponent(location.pathname);
+		a.href += `?referrer=${referrer}`;
+	});
 	if (useragent.isWebAppCapableDevice(navigator.userAgent)) {
 		showWebAppLink();
 	} else if (useragent.isModernAndroidDevice(navigator.userAgent)) {

--- a/opt-out/index.js
+++ b/opt-out/index.js
@@ -17,16 +17,20 @@ function showAndroidLink () {
 	});
 }
 
-function init () {
+function addReferrerToOptoutLink () {
 	$$('.js-optout-link').forEach(a => {
-		const referrer = encodeURIComponent(location.pathname);
-		a.href += `?referrer=${referrer}`;
+		const param = 'referrer=' + encodeURIComponent(location.href);
+		a.search = a.search + (a.search.length ? '&' : '?') + param;
 	});
+}
+
+function init () {
 	if (useragent.isWebAppCapableDevice(navigator.userAgent)) {
 		showWebAppLink();
 	} else if (useragent.isModernAndroidDevice(navigator.userAgent)) {
 		showAndroidLink();
 	}
+	addReferrerToOptoutLink();
 }
 
 module.exports = { init };


### PR DESCRIPTION
/cc @matthew-andrews @adambraimbridge 

By using this parameter rather than the value of the `Referer` header (used [here](https://github.com/Financial-Times/next-opt-in-out/blob/master/server/controllers/opt-out-form.js#L20)) we may forever banish the unpredictable redirections when landing back on Falcon after opting out of Next FT.com (and thereby satisfy [this jira ticket](https://jira.ft.com/browse/NFT-534))