### PR TITLE
Logo only header version

### DIFF
--- a/header/partials/header/top.html
+++ b/header/partials/header/top.html
@@ -1,28 +1,32 @@
 <div class="o-header__row o-header__top" data-trackable="header-top">
 	<div class="o-header__container">
 		<div class="o-header__top-wrapper">
-			<div class="o-header__top-column o-header__top-column--left">
-				{{#if @root.flags.fancyDrawer}}
-				<a href="#o-header-drawer" class="o-header__top-link o-header__top-link--menu" aria-controls="o-header-drawer" data-trackable="drawer-toggle">
-					<span class="o-header__top-link-label">Menu</span>
-				</a>
-				{{/if}}
-				<a href="#o-header-search-primary" class="o-header__top-link o-header__top-link--search" aria-controls="o-header-search-primary" data-trackable="search-toggle">
-					<span class="o-header__top-link-label">Search</span>
-				</a>
-			</div>
+			{{#unlessEquals nUi.header.variant 'logo-only'}}
+				<div class="o-header__top-column o-header__top-column--left">
+					{{#if @root.flags.fancyDrawer}}
+					<a href="#o-header-drawer" class="o-header__top-link o-header__top-link--menu" aria-controls="o-header-drawer" data-trackable="drawer-toggle">
+						<span class="o-header__top-link-label">Menu</span>
+					</a>
+					{{/if}}
+					<a href="#o-header-search-primary" class="o-header__top-link o-header__top-link--search" aria-controls="o-header-search-primary" data-trackable="search-toggle">
+						<span class="o-header__top-link-label">Search</span>
+					</a>
+				</div>
+			{{/unlessEquals}}
 			<div class="o-header__top-column o-header__top-column--center">
 				<a class="o-header__top-logo" data-trackable="logo" href="/" title="Go to Financial Times homepage">
 					<span class="o-header__visually-hidden">Financial Times</span>
 				</a>
 			</div>
-			<div class="o-header__top-column o-header__top-column--right" role="navigation" aria-label="Account and personalisation links">
-				{{#with @root.navigationLists.account.myft}}
-				<a class="o-header__top-link o-header__top-link--myft" href="{{href}}" data-trackable="my-ft" data-tour-stage="myFt" aria-label="My F T">
-					<span class="o-header__visually-hidden">myFT</span>
-				</a>
-				{{/with}}
-			</div>
+			{{#unlessEquals nUi.header.variant 'logo-only'}}
+				<div class="o-header__top-column o-header__top-column--right" role="navigation" aria-label="Account and personalisation links">
+					{{#with @root.navigationLists.account.myft}}
+					<a class="o-header__top-link o-header__top-link--myft" href="{{href}}" data-trackable="my-ft" data-tour-stage="myFt" aria-label="My F T">
+						<span class="o-header__visually-hidden">myFT</span>
+					</a>
+					{{/with}}
+				</div>
+			{{/unlessEquals}}
 		</div>
 	</div>
 </div>

--- a/header/template.html
+++ b/header/template.html
@@ -5,25 +5,33 @@
 {{#if content.before}}
 	<div class="o-header-before">{{{content.before}}}</div>
 {{/if}}
-{{> n-ui/header/partials/marketing-promo/template}}
+{{#unlessEquals nUi.header.variant 'logo-only'}}
+	{{> n-ui/header/partials/marketing-promo/template}}
+{{/unlessEquals}}
 
 <header class="o-header" data-o-component="o-header" id="primary-nav" data-o-header--no-js>
-	{{> n-ui/header/partials/header/anon}}
-	{{> n-ui/header/partials/header/top}}
-	{{> n-ui/header/partials/header/search context="primary"}}
-	{{> n-ui/header/partials/header/nav}}
+	{{#ifEquals nUi.header.variant 'logo-only'}}
+		{{> n-ui/header/partials/header/top}}
+	{{else}}
+		{{> n-ui/header/partials/header/anon}}
+		{{> n-ui/header/partials/header/top}}
+		{{> n-ui/header/partials/header/search context="primary"}}
+		{{> n-ui/header/partials/header/nav}}
+	{{/ifEquals}}
 
 	{{#outputBlock 'sub-header'}}{{/outputBlock}}
 
-	{{!-- old compatibility template --}}
-	{{!-- TODO: switch all uses to res.locals.subnav = { breadcrumb: [], subsections: [] } --}}
-	{{#ifAll @root.flags.sectionBreadcrumbs @root.currentNav}}
-		{{>n-ui/header/partials/subnav/template-old}}
-	{{/ifAll}}
+	{{#unlessEquals nUi.header.variant 'logo-only'}}
+		{{!-- old compatibility template --}}
+		{{!-- TODO: switch all uses to res.locals.subnav = { breadcrumb: [], subsections: [] } --}}
+		{{#ifAll @root.flags.sectionBreadcrumbs @root.currentNav}}
+			{{>n-ui/header/partials/subnav/template-old}}
+		{{/ifAll}}
 
-	{{#if @root.subnav}}
-		{{>n-ui/header/partials/subnav/template-new}}
-	{{/if}}
+		{{#if @root.subnav}}
+			{{>n-ui/header/partials/subnav/template-new}}
+		{{/if}}
+	{{/unlessEquals}}
 </header>
 
 {{#if @root.flags.stickyNav}}


### PR DESCRIPTION
(depends on https://github.com/Financial-Times/n-handlebars/pull/31)

e.g.

```
res.render(
    'some-template', 
    { 
        nUi: { 
            header: { 
                variant: 'logo-only' 
            }
        }
    }
);
````