### PR TITLE
Show full button text in welcome message/stack welcome buttons

### DIFF
--- a/opt-out/template.html
+++ b/opt-out/template.html
@@ -1,7 +1,7 @@
 {{#if @root.flags.optInOut}}
 	{{#unless @root.forceOptInDevice}}
 		<a class="{{classname}} js-optout-link" data-trackable="opt-out" href="{{@root.navigation.lists.account.optout.href}}">
-			Return to <span class="{{classname}}-extended">the old</span> FT.com
+			Return to the old FT.com
 		</a>
 	{{/unless}}
 	<a class="{{classname}} js-webapp-link" data-trackable="visit-webapp" href="https://app.ft.com" hidden>Open in app</a>

--- a/welcome-message/main.scss
+++ b/welcome-message/main.scss
@@ -86,14 +86,6 @@
 		white-space: nowrap;
 	}
 
-	.n-welcome-message__button-extended {
-		display: none;
-
-		@include oGridRespondTo('L') {
-			display: inline;
-		}
-	}
-
 	.n-welcome-message__close {
 		@include oIconsGetIcon('cross-disk', getColor('grey-tint4'), 20);
 		position: absolute;

--- a/welcome-message/main.scss
+++ b/welcome-message/main.scss
@@ -57,8 +57,6 @@
 	.n-welcome-message__column--message {}
 
 	.n-welcome-message__column--actions {
-		white-space: nowrap;
-
 		@include oGridRespondTo('L') {
 			text-align: right;
 		}
@@ -66,7 +64,7 @@
 
 	.n-welcome-message__heading {
 		@include oTypographySansSize('m');
-		margin: 0 0 12px;
+		margin: 0 0 $spacing-unit/4;
 	}
 
 	.n-welcome-message__intro {
@@ -84,12 +82,8 @@
 
 	.n-welcome-message__button {
 		@include oButtons($theme:'standout');
-		margin-left: 6px;
+		margin: $spacing-unit/2 $spacing-unit/2 0 0;
 		white-space: nowrap;
-
-		&:first-child {
-			margin-left: 0;
-		}
 	}
 
 	.n-welcome-message__button-extended {

--- a/welcome-message/message.html
+++ b/welcome-message/message.html
@@ -9,7 +9,7 @@
 	</div>
 	<div class="n-welcome-message__column n-welcome-message__column--actions">
 		<a class="n-welcome-message__button n-welcome-message__button--feedback" data-trackable="nps-feedback" href="/nps-feedback">
-			<span class="n-welcome-message__button-extended">Provide</span> Feedback
+			Provide Feedback
 		</a>
 		{{>n-ui/opt-out/template classname='n-welcome-message__button'}}
 	</div>


### PR DESCRIPTION
- Stack buttons when necessary, rather than trying to squeeze everything in on one line
- Show the full button text for all breakpoints

This addresses [NFT-564](https://jira.ft.com/browse/NFT-564), where it was pointed out that it’s confusing to have “Return to FT.com” on small screens, rather than the full, “Return to the old FT.com”.

/cc @i-like-robots 