### PR TITLE
feat(tracking): track segmentID if cookie is present

### DIFF
--- a/tracking/ft/index.js
+++ b/tracking/ft/index.js
@@ -64,6 +64,10 @@ const oTrackingWrapper = {
 
 			const edition = document.querySelector('[data-next-edition]') ? document.querySelector('[data-next-edition]').getAttribute('data-next-edition') : null;
 			context.edition = edition;
+			const segmentID = String(document.cookie).match(/(?:^|;)\s*segmentID=([^;]+)/) || [];
+			if (segmentID[1]) {
+				context.segmentID = segmentID[1];
+			}
 
 			oTracking.init({
 				server: 'https://spoor-api.ft.com/ingest',


### PR DESCRIPTION
This change detects if the `segmentID` cookie is present, and, if so, adds it to the o-tracking context object, so that it is tracked for all events on the page. segmentID is set as a session cookie, and is not always present.

segmentID is used for campaign tracking for inbound ads, through - for example - facebook ads. We need to track segmentID so we can attach anonymous user journeys to particular campaigns.

Based on git blame data, I'm going to ping @wheresrhys, @GlynnPhillips and @commuterjoy for anyone who fancies reviewing. I'm also going to ping @ironsidevsquincy @matthew-andrews who I've spoken to about the requirements for this. @matthew-andrews also suggests @i-like-robots as a potential reviewer.