### PR TITLE
feat(segments): hide wecome message if coming from segment

### DIFF
--- a/welcome-message/index.js
+++ b/welcome-message/index.js
@@ -17,6 +17,15 @@ function init () {
 	const fixedEl = $('.n-welcome-message--fixed');
 	const staticEl = $('.n-welcome-message--static');
 
+	const segmentId = String(document.cookie).match(/(?:^|;)\s*segmentID=/);
+	if (segmentId) {
+		if (hasLocalStorage()) {
+			superstore.local.set(STORAGE_KEY, 1);
+		}
+		fixedEl.hidden = true;
+		staticEl.hidden = true;
+	}
+
 	if (Boolean(superstore.local.get(STORAGE_KEY)) === false && hasLocalStorage()) {
 		const closeButton = $('button', fixedEl);
 


### PR DESCRIPTION
This change will intentionally hide the "welcome to next" message if the user has a segmentId cookie.

Users with segmentId have come from inbound ad channels, and are forced into next - and as such the opt-in notification does not fit with their user journey. There is no journey on Falcon for these users, so they have to be on next - we should avoid telling them they can have the same experience by opting out (because they wont).

Blame log says @wheresrhys @i-like-robots should check this out. Also paging @matthew-andrews @ironsidevsquincy who've been briefed on the business requirements for this change.