### PR TITLE
Throw a hard error (bail) if webpack fails

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ test-unit-dev:
 	karma start karma.conf.js --single-run false --auto-watch true
 
 test-build:
-	webpack --config webpack.config.demo.js
+	webpack --config webpack.config.demo.js --bail
 
 pre-package:
 	rm -rf bower_components/n-ui 2>/dev/null


### PR DESCRIPTION
Throw a hard error (bail) if webpack fails to ensure that make test doesn't have a false positive.

/cc @ironsidevsquincy 