### PR TITLE
fix(segmentId): change context key to `marketing_segment_id`

### DIFF
--- a/tracking/ft/index.js
+++ b/tracking/ft/index.js
@@ -66,7 +66,7 @@ const oTrackingWrapper = {
 			context.edition = edition;
 			const segmentID = String(document.cookie).match(/(?:^|;)\s*segmentID=([^;]+)/) || [];
 			if (segmentID[1]) {
-				context.segmentID = segmentID[1];
+				context['marketing_segment_id'] = segmentID[1];
 			}
 
 			oTracking.init({


### PR DESCRIPTION
data team have asked this to be changed from `segmentID` to `marketing_segment_id`