### PR TITLE
Refactor segment

### DIFF
--- a/tracking/ft/index.js
+++ b/tracking/ft/index.js
@@ -64,9 +64,9 @@ const oTrackingWrapper = {
 
 			const edition = document.querySelector('[data-next-edition]') ? document.querySelector('[data-next-edition]').getAttribute('data-next-edition') : null;
 			context.edition = edition;
-			const segmentID = String(document.cookie).match(/(?:^|;)\s*segmentID=([^;]+)/) || [];
-			if (segmentID[1]) {
-				context['marketing_segment_id'] = segmentID[1];
+			const segmentId = String(window.location.search).match(/[?&]segmentId=([^?&])/) || [];
+			if (segmentId[1]) {
+				context['marketing_segment_id'] = segmentId[1];
 			}
 
 			oTracking.init({

--- a/tracking/ft/index.js
+++ b/tracking/ft/index.js
@@ -66,7 +66,7 @@ const oTrackingWrapper = {
 			context.edition = edition;
 			const segmentID = String(document.cookie).match(/(?:^|;)\s*segmentID=([^;]+)/) || [];
 			if (segmentID[1]) {
-				context.segmentID = segmentID[1];
+				context['marketing_segment_id'] = segmentID[1];
 			}
 
 			oTracking.init({

--- a/welcome-message/index.js
+++ b/welcome-message/index.js
@@ -17,7 +17,7 @@ function init () {
 	const fixedEl = $('.n-welcome-message--fixed');
 	const staticEl = $('.n-welcome-message--static');
 
-	const segmentId = String(document.cookie).match(/(?:^|;)\s*segmentID=/);
+	const segmentId = String(window.location.search).match(/[?&]segmentId=([^?&])/);
 	if (segmentId) {
 		if (hasLocalStorage()) {
 			superstore.local.set(STORAGE_KEY, 1);


### PR DESCRIPTION
> data team have asked this to be changed from `segmentID` to `marketing_segment_id`


> After talking with @commuterjoy about the use of cookies, and how spoor will track
context across visits, it was decided that this should use the query parameter over
a cookie, as we should minimise the amount of cookies that users have - especially
when it can be done another way. This change switches from the use of cookie detection
for segmentId to using the query param instead.

> This requires Financial-Times/ft.com-cdn#199 to be closed,
before going live.