### PR TITLE
Tracking - pick page-meta from document & add to page view context

### DIFF
--- a/tracking/ft/index.js
+++ b/tracking/ft/index.js
@@ -68,6 +68,15 @@ const oTrackingWrapper = {
 			if (segmentId[1]) {
 				context['marketing_segment_id'] = segmentId[1];
 			}
+			const pageMetaEl = document.querySelector('[data-page-meta]');
+			let pageMeta;
+			if (pageMetaEl) {
+				try {
+					pageMeta = JSON.parse(pageMetaEl.innerHTML);
+				} catch (e) {
+				}
+			}
+			if (pageMeta) Object.assign(context, pageMeta);
 
 			oTracking.init({
 				server: 'https://spoor-api.ft.com/ingest',

--- a/tracking/ft/index.js
+++ b/tracking/ft/index.js
@@ -68,17 +68,10 @@ const oTrackingWrapper = {
 			if (segmentId[1]) {
 				context['marketing_segment_id'] = segmentId[1];
 			}
-			const pageMetaEl = window.FT && window.FT.pageMeta;
-			console.log('XXXXXXX window.FT ', window.FT);
-			let pageMeta;
-			if (pageMetaEl) {
-				try {
-					pageMeta = JSON.parse(pageMetaEl);
-				} catch (e) {
-				}
+			const pageMeta = window.FT && window.FT.pageMeta;
+			if (pageMeta && (pageMeta === Object(pageMeta))) {
+				Object.assign(context, pageMeta);
 			}
-			console.log('XXXXXXX pageMeta ', pageMeta);
-			if (pageMeta) Object.assign(context, pageMeta);
 
 			oTracking.init({
 				server: 'https://spoor-api.ft.com/ingest',

--- a/tracking/ft/index.js
+++ b/tracking/ft/index.js
@@ -70,7 +70,11 @@ const oTrackingWrapper = {
 			}
 			const pageMeta = window.FT && window.FT.pageMeta;
 			if (pageMeta && (pageMeta === Object(pageMeta))) {
-				Object.assign(context, pageMeta);
+				for (var key in pageMeta) {
+					if (pageMeta.hasOwnProperty(key)) {
+						context[key] = pageMeta[key];
+					}
+				}
 			}
 
 			oTracking.init({

--- a/tracking/ft/index.js
+++ b/tracking/ft/index.js
@@ -68,14 +68,16 @@ const oTrackingWrapper = {
 			if (segmentId[1]) {
 				context['marketing_segment_id'] = segmentId[1];
 			}
-			const pageMetaEl = document.querySelector('[data-page-meta]');
+			const pageMetaEl = window.FT && window.FT.pageMeta;
+			console.log('XXXXXXX window.FT ', window.FT);
 			let pageMeta;
 			if (pageMetaEl) {
 				try {
-					pageMeta = JSON.parse(pageMetaEl.innerHTML);
+					pageMeta = JSON.parse(pageMetaEl);
 				} catch (e) {
 				}
 			}
+			console.log('XXXXXXX pageMeta ', pageMeta);
 			if (pageMeta) Object.assign(context, pageMeta);
 
 			oTracking.init({


### PR DESCRIPTION
cc: @wheresrhys @adambraimbridge

Give the capability for apps to render a JSON object into the document tagged with `data-page-meta` that can then be added to the context property of the page view dispatched via oTracking.