### PR TITLE
Prevents the stickyNav loading on overlay barrier test

### DIFF
--- a/header/index.js
+++ b/header/index.js
@@ -7,7 +7,7 @@ function init (flags) {
 
 	new OHeader();
 
-	if (flags.get('stickyNav')) {
+	if (flags.get('stickyNav') && (flags.get('barrierOverlay') !== 'overlay' && flags.get('barrierOverlay') !== 'overlayText')) {
 		new OHeader(document.querySelector('[data-o-header--sticky]'));
 	}
 


### PR DESCRIPTION
We are about to run some AB tests on the barriers and some of the variants require the stickyNav to be disabled
