### PR TITLE
Remove ft-metadata dependencies

### DIFF
--- a/ads/js/oAdsConfig.js
+++ b/ads/js/oAdsConfig.js
@@ -1,5 +1,4 @@
 const utils = require('./utils');
-const metadata = require('ft-metadata');
 const sandbox = require('./sandbox');
 const extend = require('o-ads').utils.extend;
 const pageType = utils.getAppName();
@@ -35,15 +34,23 @@ function getLazyLoadConfig (flags) {
 
 module.exports = function (flags, contextData, userData) {
 	const gptUnitName = getGPTUnitName(contextData);
+	const eidMatch = document.cookie.match(/EID=(\d+)/);
+
+	//Temporarily get EID from FT_U cookie until all ad systems stop using it
+	const userCookieMetadata = {
+		eid: eidMatch && eidMatch.length > 1 ? eidMatch[1] : null
+	};
+
 	const targeting = extend({
 		pt: pageType.toLowerCase().substr(0, 3),
 		nlayout: utils.getLayoutName()
-	}, metadata.user(true));
+	}, userCookieMetadata);
+
 
 	const kruxConfig = (flags.get('krux')) && {
 		id: 'KHUSeE3x',
 		attributes: {
-			user: metadata.user(),
+			user: userCookieMetadata,
 			page: {
 				unitName: gptUnitName
 			}

--- a/ads/test/oAdsConfig.spec.js
+++ b/ads/test/oAdsConfig.spec.js
@@ -1,5 +1,4 @@
 /* globals describe, it, beforeEach, afterEach,expect,sinon */
-const metadata = require('ft-metadata');
 const utils = require('../js/utils');
 const oAdsConfig = require('../js/oAdsConfig');
 const adsSandbox = require('../js/sandbox');
@@ -27,37 +26,7 @@ describe('Config', () => {
 					break;
 			}
 		});
-		sandbox.stub(metadata, 'user', (param) => {
-			if(param){
-				return {
-					'02': '02',
-					'05': null,
-					'06': '06',
-					'07': '07',
-					'19': '19',
-					'40': '40',
-					'41': '41',
-					'42': '42',
-					'46': '46',
-					'51': null,
-					'slv': 'lv2',
-					'98': '98'
-				};
-			} else {
-				return {
-					gender: '02',
-					job_responsibility: '06',
-					job_position: '07',
-					company_size: '19',
-					DB_company_size: '40',
-					DB_industry: '41',
-					DB_company_turnover: '42',
-					cameo_investor_code: '46',
-					'slv': 'lv2',
-					'98': '98'
-				};
-			}
-		});
+
 	});
 
 	afterEach(() => {
@@ -83,18 +52,10 @@ describe('Config', () => {
 
 	it('Should set krux configuration when flag is set to false', () => {
 		const flags = { get: () => true };
+		document.cookie = "FT_U=EID=1234_PID=abc";
 		const config = oAdsConfig(flags, {});
 		const userExpectation = {
-			gender: '02',
-			job_responsibility: '06',
-			job_position: '07',
-			company_size: '19',
-			DB_company_size: '40',
-			DB_industry: '41',
-			DB_company_turnover: '42',
-			cameo_investor_code: '46',
-			'slv': 'lv2',
-			'98': '98'
+			eid: '1234'
 		};
 
 		expect(config.krux.id).to.be.ok;
@@ -112,7 +73,9 @@ describe('Config', () => {
 	it('Should set dfp_targeting config', () => {
 		const flags = { get: () => true };
 		const config = oAdsConfig(flags, {});
-		const expectation = 'pt=unk;02=02;05=null;06=06;07=07;19=19;40=40;41=41;42=42;46=46;51=null;slv=lv2;98=98;nlayout=custom'.split(';');
+		document.cookie = "FT_U=EID=1234_PID=abc";
+		const expectation = 'pt=unk;eid=1234;nlayout=custom'.split(';');
+
 		expectation.forEach((value) => expect(config.dfp_targeting).to.contain(value));
 	});
 

--- a/bower.json
+++ b/bower.json
@@ -19,7 +19,6 @@
     "awesomplete": "^1.1.1",
     "babel-polyfill-silencer": "^1.1.0",
     "fontfaceobserver": "^1.7.1",
-    "ft-metadata": "https://github.com/Financial-Times/ft-metadata.git#^0.0.2",
     "ftdomdelegate": "^2.0.3",
     "loadcss": "filamentgroup/loadCSS#^1.2.0",
     "n-message-prompts": "^3.0.0",


### PR DESCRIPTION
@wheresrhys @VladDubrovskis @andrewgeorgiou1981 @gvonkoss 
Removes dependency on ft-metadata (and as a result AYSC cookie).

Temporarily get the Erights ID fromthe FT_U cookie (until we move all systems off the erights - which should be soon, once the Web App do some work). Note this was done in ft-metadata, so just moving it here.