### PR TITLE
Fix myft promo default float to show buttons

### DIFF
--- a/myft-digest-promo/main.scss
+++ b/myft-digest-promo/main.scss
@@ -6,6 +6,7 @@ $icon-width-m: 90px;
 	@include oGridColspan($span: 12);
 
 	display: none;
+	float: none;
 	position: relative;
 	background-color: getColor('warm-5'); //#fdf8f2;
 	border-bottom: 1px solid getColor('warm-3'); //#cec6b9; //warm-3


### PR DESCRIPTION
The `oGridColspan` introduced an `float:left` which broke the button flow. Having to override to fix the issue.