### PR TITLE
Update mouseflow.js

### DIFF
--- a/tracking/third-party/mouseflow.js
+++ b/tracking/third-party/mouseflow.js
@@ -21,7 +21,7 @@ module.exports = function (flags) {
 		if (isSignUpApp) {
 			enableMouseflow();
 		}
-		if (hasLightSignup && Math.round(Math.random() * 100) === 1) {
+		if (hasLightSignup && Math.random() <= 0.01) {
 			enableMouseflow();
 		}
 		else {

--- a/tracking/third-party/mouseflow.js
+++ b/tracking/third-party/mouseflow.js
@@ -28,7 +28,7 @@ module.exports = function (flags) {
 			const spoorNumberDec = parseInt(spoorNumberTrim, 16)
 
 			if (spoorNumberDec % 1000 === 0) {
-				enableMouseflow();
+				// enableMouseflow();
 			}
 		}
 	}

--- a/tracking/third-party/mouseflow.js
+++ b/tracking/third-party/mouseflow.js
@@ -18,7 +18,10 @@ module.exports = function (flags) {
 	}
 	else if (flags.get('mouseflow')) {
 
-		if (isSignUpApp || hasLightSignup) {
+		if (isSignUpApp) {
+			enableMouseflow();
+		}
+		if (hasLightSignup && Math.round(Math.random() * 100) === 1) {
 			enableMouseflow();
 		}
 		else {
@@ -27,8 +30,8 @@ module.exports = function (flags) {
 			const spoorNumberTrim = spoorNumber.substring(spoorNumber.length - 12, spoorNumber.length); // Don't overflow the int
 			const spoorNumberDec = parseInt(spoorNumberTrim, 16)
 
-			if (spoorNumberDec % 1000 === 0) {
-				// enableMouseflow();
+			if (spoorNumberDec % 100 === 0) {
+				enableMouseflow();
 			}
 		}
 	}


### PR DESCRIPTION
Looking at this with pause I noticed the light signup is what's driving up the numbers here @adambraimbridge 

So now we capture:
- signup views (~150 a day)
- random 1% of light signup views (~1200 a day)
- 1% of _visitors_ by spoorid (~1000 a day)

If those calculations are correct, we'll be fairly below our mouseflow quota, so I'll test this out for a bit and increase #3 up to near capacity. This will hopefully help us get better recordings results in Beacon!