### PR TITLE
Page blacklist for the myFT digest promo

### DIFF
--- a/myft-digest-promo/index.js
+++ b/myft-digest-promo/index.js
@@ -10,6 +10,10 @@ const CLASSES = {
 	promoEnabled:'n-myft-digest-promo--enabled'
 };
 
+const pageBlacklist = [
+	'/us-election-2016'
+];
+
 let btn;
 let element;
 let conceptId;
@@ -26,6 +30,11 @@ function bindListeners () {
 }
 
 function shouldShowPromo (conceptId){
+
+	if(pageBlacklist.includes(window.location.pathname)) {
+		return Promise.resolve(false);
+	}
+
 	return Promise.all([
 		myFtClient.get('followed', 'concept', conceptId),
 		myFtClient.get('preferred', 'preference', 'email-digest')


### PR DESCRIPTION
Don't know how happy people will be with me gaffa-taping n-ui, but currently the [us-election-2016 stream page](https://www.ft.com/us-election-2016) has an extra component on it, and that component is overriding some origami styles that are depended on by the myFT promo.

Hopefully this will be a temporary measure while we get the root cause resolved.

It should look like this:
![screen shot 2016-09-15 at 16 53 11](https://cloud.githubusercontent.com/assets/4622378/18557009/219290d4-7b65-11e6-9161-7e9e2d87f007.png)

But on the us elections page it currently looks like this:
![screen shot 2016-09-15 at 16 53 21](https://cloud.githubusercontent.com/assets/4622378/18557004/1daac2e8-7b65-11e6-80b7-b405fd7a7d19.png)
