### PR TITLE
Make our styles beat the us-election info styles

### DIFF
--- a/myft-digest-promo/main.scss
+++ b/myft-digest-promo/main.scss
@@ -10,96 +10,99 @@ $icon-width-m: 90px;
 	background-color: getColor('warm-5');
 	border-bottom: 1px solid getColor('warm-3');
 	border-top: 1px solid getColor('warm-3');
-}
 
-.n-myft-digest-promo--enabled {
-	display: block;
-}
-
-.n-myft-digest-promo__container {
-	position: relative;
-	@include oGridRespondTo('M') {
-		@include oGridCenter;
-		@include oGridOffset(2);
-	}
-}
-
-.n-myft-digest-promo__dismiss-btn {
-	position: absolute;
-	top: 5px;
-	right: 0;
-	background-color: transparent;
-	border-color: transparent;
-
-	&::before {
-		@include oIconsGetIcon('cross-disk', getColor('grey-tint5'), 20);
-		position: absolute;
-		top: 0;
-		right: 0;
-		content: '';
-	}
-}
-
-.n-myft-digest-promo__content {
-	position: relative;
-	padding-left: $icon-width-s;
-	padding-top: $spacing-unit;
-
-	&::before {
-		position: absolute;
-		content: '';
+	&.n-myft-digest-promo--enabled {
 		display: block;
-		width: $icon-width-s;
-		height: 80px;
-		left: 0px;
-		background-image: url("https://next-geebee.ft.com/image/v1/images/raw/https%3A%2F%2Fnext-geebee.ft.com%2Fassets%2Fmyft-alerts-prefs%2Fenvelope.svg?source=next&fit=scale-down&compression=best&width=50https://next-geebee.ft.com/image/v1/images/raw/https%3A%2F%2Fnext-geebee.ft.com%2Fassets%2Fmyft-alerts-prefs%2Fenvelope.svg?source=next&fit=scale-down&compression=best&width=50");
-		background-repeat: no-repeat;
-		background-size: 60px auto;
-		background-position: 10px 0;
 	}
 
-	@include oGridRespondTo('M') {
-		padding-left: $icon-width-m;
-
-		&::before {
-			width: $icon-width-m;
+	.n-myft-digest-promo__container {
+		position: relative;
+		@include oGridRespondTo('M') {
+			@include oGridCenter;
+			@include oGridOffset(2);
 		}
 	}
-}
 
-.n-myft-digest-promo__heading {
-	margin-top: 0px;
-	margin-bottom: 7px;
-}
+	.n-myft-digest-promo__dismiss-btn {
+		position: absolute;
+		top: 5px;
+		right: 0;
+		background-color: transparent;
+		border-color: transparent;
 
-.n-myft-digest-promo__para {
-	margin-top: 0px;
-}
-
-.n-myft-digest-promo__branding {
-	font-weight: normal;
-	white-space: nowrap;
-}
-
-.n-myft-digest-promo__cta-wrapper {
-	display: flex;
-	overflow: auto;
-	align-items: flex-end;
-	justify-content: flex-end;
-	padding-bottom: $spacing-unit;
-	clear: both;
-}
-
-.n-myft-digest-promo__cta-btn {
-	display: inline-block;
-	text-transform: none;
-	width: 100%;
-	margin-left: 80px;
-
-@include oGridRespondTo('M') {
-		min-width: 150px;
-		width: 150px;
-		margin-left: 0;
-		float: right;
+		&::before {
+			@include oIconsGetIcon('cross-disk', getColor('grey-tint5'), 20);
+			position: absolute;
+			top: 0;
+			right: 0;
+			content: '';
+		}
 	}
+
+	.n-myft-digest-promo__content {
+		position: relative;
+		padding-left: $icon-width-s;
+		padding-top: $spacing-unit;
+
+		&::before {
+			position: absolute;
+			content: '';
+			display: block;
+			width: $icon-width-s;
+			height: 80px;
+			left: 0px;
+			background-image: url("https://next-geebee.ft.com/image/v1/images/raw/https%3A%2F%2Fnext-geebee.ft.com%2Fassets%2Fmyft-alerts-prefs%2Fenvelope.svg?source=next&fit=scale-down&compression=best&width=50https://next-geebee.ft.com/image/v1/images/raw/https%3A%2F%2Fnext-geebee.ft.com%2Fassets%2Fmyft-alerts-prefs%2Fenvelope.svg?source=next&fit=scale-down&compression=best&width=50");
+			background-repeat: no-repeat;
+			background-size: 60px auto;
+			background-position: 10px 0;
+		}
+
+		@include oGridRespondTo('M') {
+			padding-left: $icon-width-m;
+
+			&::before {
+				width: $icon-width-m;
+			}
+		}
+	}
+
+	.n-myft-digest-promo__heading {
+		@include oTypographySansBold(m);
+
+		margin-top: 0px;
+		margin-bottom: 7px;
+	}
+
+	.n-myft-digest-promo__para {
+		margin-top: 0px;
+	}
+
+	.n-myft-digest-promo__branding {
+		font-weight: normal;
+		white-space: nowrap;
+	}
+
+	.n-myft-digest-promo__cta-wrapper {
+		display: flex;
+		overflow: auto;
+		align-items: flex-end;
+		justify-content: flex-end;
+		padding-bottom: $spacing-unit;
+		clear: both;
+	}
+
+	.n-myft-digest-promo__cta-btn {
+		display: inline-block;
+		text-transform: none;
+		width: 100%;
+		margin-left: 80px;
+
+		@include oGridRespondTo('M') {
+			min-width: 150px;
+			width: 150px;
+			margin-left: 0;
+			float: right;
+		}
+	}
+
 }


### PR DESCRIPTION
There's a component on the [us-election-2016 stream page](https://www.ft.com/us-election-2016) that has its own style tag. The style tag brings in o-grid and tramples some of the myFT promo styles. It also sets a font size and weight `h2` tags, which the myFT promo was relying on.

This PR nests the myFT promo styles in the parent element class, helping it win the specificity fight (two classes beats defined-lower-down).

It also explicitly sets the myFT promo heading font so it's not affected by the h2 overrides.

Before:
![screen shot 2016-09-16 at 14 41 59](https://cloud.githubusercontent.com/assets/4622378/18587919/3228bb1e-7c1c-11e6-8e0a-21ac4e7109ba.png)

After:
![screen shot 2016-09-16 at 14 42 06](https://cloud.githubusercontent.com/assets/4622378/18587910/2bba9c70-7c1c-11e6-82ed-5fd19bd848bd.png)
