### PR TITLE
Tour component tweaks

### DIFF
--- a/tour-tip/component.js
+++ b/tour-tip/component.js
@@ -7,10 +7,10 @@ export default class TourTip extends Component {
 	render () {
 		let attrs = JSON.parse(JSON.stringify(this.props.data));
 
-		const classes = {
-			'tour-tip': true,
-			[`tour-tip--${attrs.settings.size}`]: attrs.settings.size,
-		};
+		const modifiers = [`tour-tip--${attrs.settings.size}`, ...(attrs.modifiers || []) ];
+		const classes = classNames({
+			'tour-tip': true
+		}, modifiers);
 
 		const createMarkup = (prop) => ({__html: prop});
 

--- a/tour-tip/component.js
+++ b/tour-tip/component.js
@@ -5,40 +5,40 @@ import { buildImageServiceUrl } from '@financial-times/n-image/src/helpers';
 
 export default class TourTip extends Component {
 	render () {
-		let attrs = JSON.parse(JSON.stringify(this.props.data));
+		let data = JSON.parse(JSON.stringify(this.props.data));
 
-		const modifiers = [`tour-tip--${attrs.settings.size}`, ...(attrs.modifiers || []) ];
+		const modifiers = [`tour-tip--${data.settings.size}`, ...(data.modifiers || []) ];
 		const classes = classNames({
 			'tour-tip': true
 		}, modifiers);
 
 		const createMarkup = (prop) => ({__html: prop});
 
-		const tourLink = (attrs.settings.hasTourPageLink) ?
+		const tourLink = (data.settings.hasTourPageLink) ?
 			(<p className="tour-tip__link"><a href="/tour" className="tour-tip__link" data-trackable="tour-link">New hints and tips</a></p>)
 			: null;
 
-		const body = (attrs.content.body) ?
-			(<p className="tour-tip__body" dangerouslySetInnerHTML={createMarkup(attrs.content.body)}></p>) : null;
+		const body = (data.content.body) ?
+			(<p className="tour-tip__body" dangerouslySetInnerHTML={createMarkup(data.content.body)}></p>) : null;
 
-		const cta = (attrs.content.ctaUrl && attrs.content.ctaLabel) ?
-			(<a href={attrs.content.ctaUrl} className="tour-tip__cta o-buttons o-buttons--standout" data-trackable="cta">{attrs.content.ctaLabel}</a>)
+		const cta = (data.content.ctaUrl && data.content.ctaLabel) ?
+			(<a href={data.content.ctaUrl} className="tour-tip__cta o-buttons o-buttons--standout" data-trackable="cta">{data.content.ctaLabel}</a>)
 			: null;
 
-		const image = (attrs.content.imageUrl) ?
+		const image = (data.content.imageUrl) ?
 			(<div className="tour-tip__img-container">
 				<Image
-					src={buildImageServiceUrl(attrs.content.imageUrl, (attrs.content.imageUrl.substr(-4,4) === '.svg') ? {format: 'svg'} : {} )}
-					alt={attrs.content.imageAlt}
+					src={buildImageServiceUrl(data.content.imageUrl, (data.content.imageUrl.substr(-4,4) === '.svg') ? {format: 'svg'} : {} )}
+					alt={data.content.imageAlt}
 					classes={['tour-tip__img']}
 				/>
 			</div>) : null;
 
-		return <div className={classes} data-trackable={`tour-tip-${attrs.id}`}>
+		return <div className={classes} data-trackable={`tour-tip-${data.id}`}>
 			<div className="tour-tip__main">
 				<div className="tour-tip__text">
 					{tourLink}
-					<h2 className="tour-tip__standout">{attrs.content.title}</h2>
+					<h2 className="tour-tip__standout">{data.content.title}</h2>
 					{body}
 					{cta}
 				</div>

--- a/tour-tip/component.js
+++ b/tour-tip/component.js
@@ -26,7 +26,7 @@ export default class TourTip extends Component {
 			(<a href={attrs.content.ctaUrl} className="tour-tip__cta o-buttons o-buttons--standout" data-trackable="cta">{attrs.content.ctaLabel}</a>)
 			: null;
 
-		return <aside className={classNames(classes)} data-trackable={`tour-tip-${attrs.id}`}>
+		return <div className={classes} data-trackable={`tour-tip-${attrs.id}`}>
 			<div className="tour-tip__main">
 				<div className="tour-tip__text">
 					{tourLink}
@@ -42,6 +42,6 @@ export default class TourTip extends Component {
 					/>
 				</div>
 			</div>
-		</aside>
+		</div>
 	}
 }

--- a/tour-tip/component.js
+++ b/tour-tip/component.js
@@ -5,7 +5,7 @@ import { buildImageServiceUrl } from '@financial-times/n-image/src/helpers';
 
 export default class TourTip extends Component {
 	render () {
-		let attrs = Object.assign({}, this.props.data);
+		let attrs = JSON.parse(JSON.stringify(this.props.data));
 
 		const classes = {
 			'tour-tip': true,

--- a/tour-tip/component.js
+++ b/tour-tip/component.js
@@ -4,45 +4,56 @@ import { Image } from '@financial-times/n-image';
 import { buildImageServiceUrl } from '@financial-times/n-image/src/helpers';
 
 export default class TourTip extends Component {
-	render () {
-		let data = JSON.parse(JSON.stringify(this.props.data));
 
-		const modifiers = [`tour-tip--${data.settings.size}`, ...(data.modifiers || []) ];
-		const classes = classNames({
-			'tour-tip': true
-		}, modifiers);
+	renderTourLink (data) {
+		if (data.settings.hasTourPageLink) {
+			return <p className="tour-tip__link"><a href="/tour" className="tour-tip__link" data-trackable="tour-link">New hints and tips</a></p>;
+		}
+	}
 
-		const createMarkup = (prop) => ({__html: prop});
+	renderBody (data) {
+		const createMarkup = (prop) => ({ __html: prop });
 
-		const tourLink = (data.settings.hasTourPageLink) ?
-			(<p className="tour-tip__link"><a href="/tour" className="tour-tip__link" data-trackable="tour-link">New hints and tips</a></p>)
-			: null;
+		if (data.content.body) {
+			return <p className="tour-tip__body" dangerouslySetInnerHTML={createMarkup(data.content.body)}></p>;
+		}
+	}
 
-		const body = (data.content.body) ?
-			(<p className="tour-tip__body" dangerouslySetInnerHTML={createMarkup(data.content.body)}></p>) : null;
+	renderCta (data) {
+		if (data.content.ctaUrl && data.content.ctaLabel) {
+			return <a href={data.content.ctaUrl} className="tour-tip__cta o-buttons o-buttons--standout" data-trackable="cta">{data.content.ctaLabel}</a>;
+		}
+	}
 
-		const cta = (data.content.ctaUrl && data.content.ctaLabel) ?
-			(<a href={data.content.ctaUrl} className="tour-tip__cta o-buttons o-buttons--standout" data-trackable="cta">{data.content.ctaLabel}</a>)
-			: null;
+	renderImage (data) {
+		if (data.content.imageUrl) {
 
-		const image = (data.content.imageUrl) ?
-			(<div className="tour-tip__img-container">
+			return <div className="tour-tip__img-container">
 				<Image
 					src={buildImageServiceUrl(data.content.imageUrl, (data.content.imageUrl.substr(-4,4) === '.svg') ? {format: 'svg'} : {} )}
 					alt={data.content.imageAlt}
 					classes={['tour-tip__img']}
 				/>
-			</div>) : null;
+			</div>;
+		}
+	}
+
+	render () {
+		let data = JSON.parse(JSON.stringify(this.props.data));
+		const modifiers = [`tour-tip--${data.settings.size}`, ...(data.modifiers || []) ];
+		const classes = classNames({
+			'tour-tip': true
+		}, modifiers);
 
 		return <div className={classes} data-trackable={`tour-tip-${data.id}`}>
 			<div className="tour-tip__main">
 				<div className="tour-tip__text">
-					{tourLink}
+					{this.renderTourLink(data)}
 					<h2 className="tour-tip__standout">{data.content.title}</h2>
-					{body}
-					{cta}
+					{this.renderBody(data)}
+					{this.renderCta(data)}
 				</div>
-				{image}
+				{this.renderImage(data)}
 			</div>
 		</div>
 	}

--- a/tour-tip/component.js
+++ b/tour-tip/component.js
@@ -40,7 +40,9 @@ export default class TourTip extends Component {
 
 	render () {
 		let data = JSON.parse(JSON.stringify(this.props.data));
-		const modifiers = [`tour-tip--${data.settings.size}`, ...(data.modifiers || []) ];
+
+		const modifiersFromConfig = (data.modifiers || []).map(modifier => `tour-tip--${modifier}`);
+		const modifiers = [`tour-tip--${data.settings.size}`, ...modifiersFromConfig];
 		const classes = classNames({
 			'tour-tip': true
 		}, modifiers);

--- a/tour-tip/component.js
+++ b/tour-tip/component.js
@@ -26,6 +26,15 @@ export default class TourTip extends Component {
 			(<a href={attrs.content.ctaUrl} className="tour-tip__cta o-buttons o-buttons--standout" data-trackable="cta">{attrs.content.ctaLabel}</a>)
 			: null;
 
+		const image = (attrs.content.imageUrl) ?
+			(<div className="tour-tip__img-container">
+				<Image
+					src={buildImageServiceUrl(attrs.content.imageUrl, (attrs.content.imageUrl.substr(-4,4) === '.svg') ? {format: 'svg'} : {} )}
+					alt={attrs.content.imageAlt}
+					classes={['tour-tip__img']}
+				/>
+			</div>) : null;
+
 		return <div className={classes} data-trackable={`tour-tip-${attrs.id}`}>
 			<div className="tour-tip__main">
 				<div className="tour-tip__text">
@@ -34,13 +43,7 @@ export default class TourTip extends Component {
 					{body}
 					{cta}
 				</div>
-				<div className="tour-tip__img-container">
-					<Image
-						src={buildImageServiceUrl(attrs.content.imageUrl, {format: 'svg'})}
-						alt={attrs.content.imageAlt}
-						classes={['tour-tip__img']}
-					/>
-				</div>
+				{image}
 			</div>
 		</div>
 	}

--- a/tour-tip/component.js
+++ b/tour-tip/component.js
@@ -27,10 +27,12 @@ export default class TourTip extends Component {
 
 	renderImage (data) {
 		if (data.content.imageUrl) {
+			const isSvgExt = data.content.imageUrl.substr(-4,4) === '.svg';
+			const imageServiceOpts = (isSvgExt) ? {format: 'svg'} : {};
 
 			return <div className="tour-tip__img-container">
 				<Image
-					src={buildImageServiceUrl(data.content.imageUrl, (data.content.imageUrl.substr(-4,4) === '.svg') ? {format: 'svg'} : {} )}
+					src={buildImageServiceUrl(data.content.imageUrl, imageServiceOpts)}
 					alt={data.content.imageAlt}
 					classes={['tour-tip__img']}
 				/>

--- a/tour-tip/component.js
+++ b/tour-tip/component.js
@@ -10,7 +10,6 @@ export default class TourTip extends Component {
 		const classes = {
 			'tour-tip': true,
 			[`tour-tip--${attrs.settings.size}`]: attrs.settings.size,
-			'tour-tip--reversed': attrs.settings.isReversed
 		};
 
 		const createMarkup = (prop) => ({__html: prop});

--- a/tour-tip/config.json
+++ b/tour-tip/config.json
@@ -4,7 +4,6 @@
     "settings": {
       "hasTourPageLink": true,
       "isDismissable": false,
-      "isReversed": false,
       "size": "s"
     },
     "content": {
@@ -20,7 +19,6 @@
     "settings": {
       "hasTourPageLink": true,
       "isDismissable": false,
-      "isReversed": false,
       "size": "m"
     },
     "content": {
@@ -37,7 +35,6 @@
     "settings": {
       "hasTourPageLink": false,
       "isDismissable": false,
-      "isReversed": false,
       "size": "l"
     },
     "content": {
@@ -54,7 +51,6 @@
     "settings": {
       "hasTourPageLink": true,
       "isDismissable": false,
-      "isReversed": false,
       "size": "s"
     },
     "content": {
@@ -70,7 +66,6 @@
     "settings": {
       "hasTourPageLink": true,
       "isDismissable": false,
-      "isReversed": false,
       "size": "m"
     },
     "content": {
@@ -87,7 +82,6 @@
     "settings": {
       "hasTourPageLink": false,
       "isDismissable": false,
-      "isReversed": false,
       "size": "l"
     },
     "content": {
@@ -102,7 +96,6 @@
     "settings": {
       "hasTourPageLink": true,
       "isDismissable": false,
-      "isReversed": false,
       "size": "s"
     },
     "content": {
@@ -118,7 +111,6 @@
     "settings": {
       "hasTourPageLink": true,
       "isDismissable": false,
-      "isReversed": false,
       "size": "m"
     },
     "content": {
@@ -135,7 +127,6 @@
     "settings": {
       "hasTourPageLink": false,
       "isDismissable": false,
-      "isReversed": false,
       "size": "l"
     },
     "content": {
@@ -150,7 +141,6 @@
     "settings": {
       "hasTourPageLink": true,
       "isDismissable": false,
-      "isReversed": false,
       "size": "s"
     },
     "content": {
@@ -166,7 +156,6 @@
     "settings": {
       "hasTourPageLink": true,
       "isDismissable": false,
-      "isReversed": false,
       "size": "m"
     },
     "content": {
@@ -183,7 +172,6 @@
     "settings": {
       "hasTourPageLink": false,
       "isDismissable": false,
-      "isReversed": false,
       "size": "l"
     },
     "content": {
@@ -198,7 +186,6 @@
     "settings": {
       "hasTourPageLink": true,
       "isDismissable": false,
-      "isReversed": false,
       "size": "s"
     },
     "content": {
@@ -214,7 +201,6 @@
     "settings": {
       "hasTourPageLink": true,
       "isDismissable": false,
-      "isReversed": false,
       "size": "m"
     },
     "content": {
@@ -231,7 +217,6 @@
     "settings": {
       "hasTourPageLink": false,
       "isDismissable": false,
-      "isReversed": false,
       "size": "l"
     },
     "content": {
@@ -248,7 +233,6 @@
     "settings": {
       "hasTourPageLink": true,
       "isDismissable": false,
-      "isReversed": false,
       "size": "s"
     },
     "content": {
@@ -264,7 +248,6 @@
     "settings": {
       "hasTourPageLink": true,
       "isDismissable": false,
-      "isReversed": false,
       "size": "m"
     },
     "content": {
@@ -281,7 +264,6 @@
     "settings": {
       "hasTourPageLink": false,
       "isDismissable": false,
-      "isReversed": false,
       "size": "l"
     },
     "content": {
@@ -296,7 +278,6 @@
     "settings": {
       "hasTourPageLink": true,
       "isDismissable": false,
-      "isReversed": false,
       "size": "s"
     },
     "content": {
@@ -312,7 +293,6 @@
     "settings": {
       "hasTourPageLink": true,
       "isDismissable": false,
-      "isReversed": false,
       "size": "m"
     },
     "content": {
@@ -329,7 +309,6 @@
     "settings": {
       "hasTourPageLink": false,
       "isDismissable": false,
-      "isReversed": false,
       "size": "l"
     },
     "content": {
@@ -344,7 +323,6 @@
     "settings": {
       "hasTourPageLink": true,
       "isDismissable": false,
-      "isReversed": false,
       "size": "s"
     },
     "content": {
@@ -360,7 +338,6 @@
     "settings": {
       "hasTourPageLink": true,
       "isDismissable": false,
-      "isReversed": false,
       "size": "m"
     },
     "content": {
@@ -377,7 +354,6 @@
     "settings": {
       "hasTourPageLink": false,
       "isDismissable": false,
-      "isReversed": false,
       "size": "l"
     },
     "content": {
@@ -392,7 +368,6 @@
     "settings": {
       "hasTourPageLink": true,
       "isDismissable": false,
-      "isReversed": false,
       "size": "s"
     },
     "content": {
@@ -408,7 +383,6 @@
     "settings": {
       "hasTourPageLink": true,
       "isDismissable": false,
-      "isReversed": false,
       "size": "m"
     },
     "content": {
@@ -425,7 +399,6 @@
     "settings": {
       "hasTourPageLink": false,
       "isDismissable": false,
-      "isReversed": false,
       "size": "l"
     },
     "content": {
@@ -440,7 +413,6 @@
     "settings": {
       "hasTourPageLink": true,
       "isDismissable": false,
-      "isReversed": false,
       "size": "s"
     },
     "content": {
@@ -456,7 +428,6 @@
     "settings": {
       "hasTourPageLink": true,
       "isDismissable": false,
-      "isReversed": false,
       "size": "m"
     },
     "content": {
@@ -473,7 +444,6 @@
     "settings": {
       "hasTourPageLink": false,
       "isDismissable": false,
-      "isReversed": false,
       "size": "l"
     },
     "content": {

--- a/tour-tip/main.scss
+++ b/tour-tip/main.scss
@@ -25,8 +25,12 @@
 	}
 
 	.tour-tip__standout {
-		@include oTypographySerif('m');
+		@include oTypographySerif('l');
 		margin: 0;
+	}
+
+	.tour-tip__body {
+		@include oTypographySans('m', $load-progressively: true);
 	}
 
 	.tour-tip__body-link {
@@ -79,7 +83,7 @@
 			}
 
 			.tour-tip__standout {
-				@include oTypographySerifSize('l');
+				@include oTypographySerifSize('xl');
 			}
 
 			.tour-tip__cta {

--- a/tour-tip/main.scss
+++ b/tour-tip/main.scss
@@ -41,14 +41,13 @@
 		margin: $spacing-unit 0 0;
 	}
 
-	.tour-tip--s {
-		.tour-tip__img-container {
-			overflow: hidden;
-		}
-		.tour-tip__img {
-			margin-bottom: -4%;
-			margin-left: -10%;
-		}
+	.tour-tip__img-container {
+		overflow: hidden;
+	}
+
+	.tour-tip__img {
+		margin-bottom: -4%;
+		margin-left: -10%;
 	}
 
 	@include oGridRespondTo($from: 'M') {


### PR DESCRIPTION
- Tweak tour font sizes
- Give image-nudging treatment to all tour variants
- Change tour tips from `<aside>`s to `<div>`s due to varying usage
- Make tour images optional
- Remove reversed tour variant (will be brought back soon)
- Allow custom BEM modifiers for tour tips
- Tidy up component

See commits for more info.