### PR TITLE
Fix flash of unstyled header

### DIFF
--- a/header/main.scss
+++ b/header/main.scss
@@ -34,7 +34,8 @@ $o-header-image-base-url: 'https://next-geebee.ft.com/image';
 
 	}
 
-	@include oHeader(('drawer', 'sticky'));
+	@include oHeaderDrawer;
+	@include oHeaderSticky;
 
 	// fix up z-indexes
 	.o-header__drawer {


### PR DESCRIPTION
Thanks for the heads up @onishiweb. Because of our build tooling, this was actually causing the header styles to be missing from the critical path css. Fixes #447