### PR TITLE
tweak to the wording on the myFT promo banner

### DIFF
--- a/myft-digest-promo/promo-message.html
+++ b/myft-digest-promo/promo-message.html
@@ -9,7 +9,7 @@
 									<h2 class="n-myft-digest-promo__heading">
 										Add to <span class="n-myft-digest-promo__branding">myFT Digest</span>
 									</h2>
-									<p class ="n-myft-digest-promo__para">Add this topic to a myFT Digest, straight to your inbox</p>
+									<p class ="n-myft-digest-promo__para">Add this topic to your myFT Digest for news straight to your inbox</p>
 								</div>
 
 								<div data-o-grid-colspan="12 M4" class="n-myft-digest-promo__cta-wrapper">


### PR DESCRIPTION
Small copy change on the myFT promo banner.

Before: 
<img width="852" alt="screen shot 2016-09-21 at 15 14 05" src="https://cloud.githubusercontent.com/assets/17549437/18714569/1d568b8a-800e-11e6-8437-fec69ab7ed6f.png">

After:
<img width="1014" alt="screen shot 2016-09-21 at 15 15 04" src="https://cloud.githubusercontent.com/assets/17549437/18714604/3911607a-800e-11e6-8e01-d06b830e4fce.png">
