### PR TITLE
Moar tour amends

### DIFF
--- a/bootstrap.scss
+++ b/bootstrap.scss
@@ -16,6 +16,8 @@
 @import 'layout/main';
 @import 'myft/main';
 @import 'myft-digest-promo/main';
+@import 'tour-tip/main';
+@import 'tour-tip-group/main';
 
 // TODO: move these components into n-ui
 @import 'cookie-message/main';

--- a/tour-tip-group/config.json
+++ b/tour-tip-group/config.json
@@ -1,0 +1,30 @@
+{
+  "intro": {
+    "id": "intro",
+    "settings": {
+      "size": "l"
+    },
+    "content": {
+      "title": "Welcome to the new FT",
+      "body": "Take a moment to see what’s changed by scrolling through our new features below.",
+      "imageAlt": "A laptop with the new FT.com loaded",
+      "imageUrl": "https://next-geebee.ft.com/assets/tour/laptop-2.png",
+      "ctaUrl": "#",
+      "ctaLabel": "Watch a video"
+    },
+    "modifiers": ["intro"]
+  },
+  "outro": {
+    "id": "outro",
+    "settings": {
+      "size": "l"
+    },
+    "content": {
+      "title": "Over to you",
+      "body": "Now you’ve seen what you can do, make the most of the new FT.com.",
+      "ctaUrl": "/",
+      "ctaLabel": "Get started"
+    },
+    "modifiers": ["outro"]
+  }
+}

--- a/tour-tip/config.json
+++ b/tour-tip/config.json
@@ -9,7 +9,7 @@
     "content": {
       "title": "Track the topics most important to you all in one place",
       "imageAlt": "Illustration of the \"Companies\" page, showing an \"Added\" button next to the page heading",
-      "imageUrl": "https://next-geebee.ft.com/assets/tour/myft-1.svg",
+      "imageUrl": "https://next-geebee.ft.com/assets/tour/myft-2.svg",
       "ctaUrl": "/tour",
       "ctaLabel": "More tips"
     }
@@ -24,7 +24,7 @@
     "content": {
       "title": "Track the topics most important to you all in one place",
       "imageAlt": "Illustration of the \"Companies\" page, showing an \"Added\" button next to the page heading",
-      "imageUrl": "https://next-geebee.ft.com/assets/tour/myft-1.svg",
+      "imageUrl": "https://next-geebee.ft.com/assets/tour/myft-2.svg",
       "ctaUrl": "/tour",
       "ctaLabel": "Discover more tips"
     }
@@ -41,7 +41,7 @@
       "title": "Make myFT yours",
       "body": "Discover thousands of concepts to track. Then you can stay updated on those most important to you, all in one place.",
       "imageAlt": "Illustration of the \"Companies\" page, showing an \"Added\" button next to the page heading",
-      "imageUrl": "https://next-geebee.ft.com/assets/tour/myft-1.svg",
+      "imageUrl": "https://next-geebee.ft.com/assets/tour/myft-2.svg",
       "ctaUrl": "/myft/product-tour",
       "ctaLabel": "Explore myFT"
     }
@@ -56,7 +56,7 @@
     "content": {
       "title": "Share 10 articles a month with non-subscribers, who can read them – absolutely free",
       "imageAlt": "Illustration of the Gift Article button in article pages",
-      "imageUrl": "https://next-geebee.ft.com/assets/tour/gift-2.svg",
+      "imageUrl": "https://next-geebee.ft.com/assets/tour/gift-3.svg",
       "ctaUrl": "/tour",
       "ctaLabel": "More tips"
     }
@@ -71,7 +71,7 @@
     "content": {
       "title": "Share 10 articles a month with non-subscribers, who can read them – absolutely free",
       "imageAlt": "Illustration of the Gift Article button in article pages",
-      "imageUrl": "https://next-geebee.ft.com/assets/tour/gift-2.svg",
+      "imageUrl": "https://next-geebee.ft.com/assets/tour/gift-3.svg",
       "ctaUrl": "/tour",
       "ctaLabel": "Discover more tips"
     }
@@ -88,7 +88,7 @@
       "title": "Gift article",
       "body": "Start the conversation. Share up to 10 articles a month with colleagues, friends or family – absolutely free. Even if they’re not subscribed to the FT.",
       "imageAlt": "Illustration of the Gift Article button in article pages",
-      "imageUrl": "https://next-geebee.ft.com/assets/tour/gift-2.svg"
+      "imageUrl": "https://next-geebee.ft.com/assets/tour/gift-3.svg"
     }
   },
   {
@@ -101,7 +101,7 @@
     "content": {
       "title": "Better filtering of trending topics in FastFT’s market-moving news",
       "imageAlt": "Illustration of the FastFT page",
-      "imageUrl": "https://next-geebee.ft.com/assets/tour/fastft-1.svg",
+      "imageUrl": "https://next-geebee.ft.com/assets/tour/fastft-2.svg",
       "ctaUrl": "/tour",
       "ctaLabel": "More tips"
     }
@@ -116,7 +116,7 @@
     "content": {
       "title": "Better filtering of trending topics in FastFT’s market-moving news",
       "imageAlt": "Illustration of the FastFT page",
-      "imageUrl": "https://next-geebee.ft.com/assets/tour/fastft-1.svg",
+      "imageUrl": "https://next-geebee.ft.com/assets/tour/fastft-2.svg",
       "ctaUrl": "/tour",
       "ctaLabel": "Discover more tips"
     }
@@ -133,7 +133,7 @@
       "title": "Improved FastFT",
       "body": "Better filtering of trending topics, same instant market-moving news and views from our global team.",
       "imageAlt": "Illustration of the FastFT page",
-      "imageUrl": "https://next-geebee.ft.com/assets/tour/fastft-1.svg",
+      "imageUrl": "https://next-geebee.ft.com/assets/tour/fastft-2.svg",
       "ctaUrl": "https://www.ft.com/fastft",
       "ctaLabel": "Try fastFT"
     }
@@ -148,7 +148,7 @@
     "content": {
       "title": "Get intuitive markets data at a glance on any device",
       "imageAlt": "Illustration of a graph in a Markets Data page",
-      "imageUrl": "https://next-geebee.ft.com/assets/tour/markets-1.svg",
+      "imageUrl": "https://next-geebee.ft.com/assets/tour/markets-3.svg",
       "ctaUrl": "/tour",
       "ctaLabel": "More tips"
     }
@@ -163,7 +163,7 @@
     "content": {
       "title": "Get intuitive markets data at a glance on any device",
       "imageAlt": "Illustration of a graph in a Markets Data page",
-      "imageUrl": "https://next-geebee.ft.com/assets/tour/markets-1.svg",
+      "imageUrl": "https://next-geebee.ft.com/assets/tour/markets-3.svg",
       "ctaUrl": "/tour",
       "ctaLabel": "Discover more tips"
     }
@@ -180,7 +180,7 @@
       "title": "Improved Markets Data tools",
       "body": "Manage price alerts on the go, compare cross currencies quickly and get a macromap view of major indices across the globe.",
       "imageAlt": "Illustration of a graph in a Markets Data page",
-      "imageUrl": "https://next-geebee.ft.com/assets/tour/markets-1.svg",
+      "imageUrl": "https://next-geebee.ft.com/assets/tour/markets-3.svg",
       "ctaUrl": "http://markets.ft.com/data/",
       "ctaLabel": "Visit Markets Data"
     }
@@ -195,7 +195,7 @@
     "content": {
       "title": "Instant, Daily or Weekly news digests delivered straight to your email inbox",
       "imageAlt": "Illustration of a myFT Instant Alert email",
-      "imageUrl": "https://next-geebee.ft.com/assets/tour/alerts-1.svg",
+      "imageUrl": "https://next-geebee.ft.com/assets/tour/alerts-2.svg",
       "ctaUrl": "/tour",
       "ctaLabel": "More tips"
     }
@@ -210,7 +210,7 @@
     "content": {
       "title": "Instant, Daily or Weekly news digests delivered straight to your email inbox",
       "imageAlt": "Illustration of a myFT Instant Alert email",
-      "imageUrl": "https://next-geebee.ft.com/assets/tour/alerts-1.svg",
+      "imageUrl": "https://next-geebee.ft.com/assets/tour/alerts-2.svg",
       "ctaUrl": "/tour",
       "ctaLabel": "Discover more tips"
     }
@@ -227,7 +227,7 @@
       "title": "myFT Alerts",
       "body": "Choose to receive Instant, Daily or Weekly digests about the topics in your myFT – delivered straight to your email inbox.",
       "imageAlt": "Illustration of a myFT Instant Alert email",
-      "imageUrl": "https://next-geebee.ft.com/assets/tour/alerts-1.svg",
+      "imageUrl": "https://next-geebee.ft.com/assets/tour/alerts-2.svg",
       "ctaUrl": "/myft/alerts",
       "ctaLabel": "Manage alerts"
     }
@@ -242,7 +242,7 @@
     "content": {
       "title": "Email briefings subscriptions can now be handled in myFT",
       "imageAlt": "Illustration of a News briefing preference in the myFT Alerts page",
-      "imageUrl": "https://next-geebee.ft.com/assets/tour/briefings-1.svg",
+      "imageUrl": "https://next-geebee.ft.com/assets/tour/briefings-2.svg",
       "ctaUrl": "/tour",
       "ctaLabel": "More tips"
     }
@@ -257,7 +257,7 @@
     "content": {
       "title": "Email briefings subscriptions can now be handled in myFT",
       "imageAlt": "Illustration of a News briefing preference in the myFT Alerts page",
-      "imageUrl": "https://next-geebee.ft.com/assets/tour/briefings-1.svg",
+      "imageUrl": "https://next-geebee.ft.com/assets/tour/briefings-2.svg",
       "ctaUrl": "/tour",
       "ctaLabel": "Discover more tips"
     }
@@ -274,7 +274,7 @@
       "title": "Email Briefings",
       "body": "You can now manage your news briefing subscriptions in myFT. Keep an eye out for further enhancements coming soon.",
       "imageAlt": "Illustration of a News briefing preference in the myFT Alerts page",
-      "imageUrl": "https://next-geebee.ft.com/assets/tour/briefings-1.svg",
+      "imageUrl": "https://next-geebee.ft.com/assets/tour/briefings-2.svg",
       "ctaUrl": "https://www.ft.com/myft/alerts",
       "ctaLabel": "Review briefings"
     }
@@ -289,7 +289,7 @@
     "content": {
       "title": "Investments at your fingertips with Portfolio access on all of your devices",
       "imageAlt": "Illustration of the FT Portfolio page",
-      "imageUrl": "https://next-geebee.ft.com/assets/tour/portfolio-1.svg",
+      "imageUrl": "https://next-geebee.ft.com/assets/tour/portfolio-2.svg",
       "ctaUrl": "/tour",
       "ctaLabel": "More tips"
     }
@@ -304,7 +304,7 @@
     "content": {
       "title": "Investments at your fingertips with Portfolio access on all of your devices",
       "imageAlt": "Illustration of the FT Portfolio page",
-      "imageUrl": "https://next-geebee.ft.com/assets/tour/portfolio-1.svg",
+      "imageUrl": "https://next-geebee.ft.com/assets/tour/portfolio-2.svg",
       "ctaUrl": "/tour",
       "ctaLabel": "Discover more tips"
     }
@@ -321,7 +321,7 @@
       "title": "Updated Portfolio tool",
       "body": "Investments at your fingertips – add, edit and track investments on all of your devices. You can choose to keep using the existing Portfolio while we perfect the new dashboard.",
       "imageAlt": "Illustration of the FT Portfolio page",
-      "imageUrl": "https://next-geebee.ft.com/assets/tour/portfolio-1.svg",
+      "imageUrl": "https://next-geebee.ft.com/assets/tour/portfolio-2.svg",
       "ctaUrl": "http://markets.ft.com/data/portfolio/dashboard",
       "ctaLabel": "Check your Portfolio"
     }
@@ -336,7 +336,7 @@
     "content": {
       "title": "Valuable reports on specific countries, industries and business topics",
       "imageAlt": "Illustration of a Special Reports page",
-      "imageUrl": "https://next-geebee.ft.com/assets/tour/reports-1.svg",
+      "imageUrl": "https://next-geebee.ft.com/assets/tour/reports-2.svg",
       "ctaUrl": "/tour",
       "ctaLabel": "More tips"
     }
@@ -351,7 +351,7 @@
     "content": {
       "title": "Valuable reports on specific countries, industries and business topics",
       "imageAlt": "Illustration of a Special Reports page",
-      "imageUrl": "https://next-geebee.ft.com/assets/tour/reports-1.svg",
+      "imageUrl": "https://next-geebee.ft.com/assets/tour/reports-2.svg",
       "ctaUrl": "/tour",
       "ctaLabel": "Discover more tips"
     }
@@ -368,7 +368,7 @@
       "title": "Special Reports",
       "body": "Get valuable insights into specific countries, industries and business topics, with hundreds of Special Reports published every year.",
       "imageAlt": "Illustration of a Special Reports page",
-      "imageUrl": "https://next-geebee.ft.com/assets/tour/reports-1.svg",
+      "imageUrl": "https://next-geebee.ft.com/assets/tour/reports-2.svg",
       "ctaUrl": "https://www.ft.com/special-reports",
       "ctaLabel": "View Special Reports"
     }
@@ -383,7 +383,7 @@
     "content": {
       "title": "Read live updates of the latest FT news, the moment the stories are published",
       "imageAlt": "Illustration of the FT News feed page",
-      "imageUrl": "https://next-geebee.ft.com/assets/tour/feed-1.svg",
+      "imageUrl": "https://next-geebee.ft.com/assets/tour/feed-2.svg",
       "ctaUrl": "/tour",
       "ctaLabel": "More tips"
     }
@@ -398,7 +398,7 @@
     "content": {
       "title": "Read live updates of the latest FT news, the moment the stories are published",
       "imageAlt": "Illustration of the FT News feed page",
-      "imageUrl": "https://next-geebee.ft.com/assets/tour/feed-1.svg",
+      "imageUrl": "https://next-geebee.ft.com/assets/tour/feed-2.svg",
       "ctaUrl": "/tour",
       "ctaLabel": "Discover more tips"
     }
@@ -415,7 +415,7 @@
       "title": "News feed",
       "body": "The news as it’s happening. Read live updates of the latest FT news, the moment the stories are published.",
       "imageAlt": "Illustration of the FT News feed page",
-      "imageUrl": "https://next-geebee.ft.com/assets/tour/feed-1.svg",
+      "imageUrl": "https://next-geebee.ft.com/assets/tour/feed-2.svg",
       "ctaUrl": "https://www.ft.com/news-feed",
       "ctaLabel": "Visit News Feed"
     }

--- a/tour-tip/main.scss
+++ b/tour-tip/main.scss
@@ -45,11 +45,6 @@
 		overflow: hidden;
 	}
 
-	.tour-tip__img {
-		margin-bottom: -4%;
-		margin-left: -10%;
-	}
-
 	@include oGridRespondTo($from: 'M') {
 		// Styling wise, ‘m’ is the same as ‘l’
 		// (there are only differences at the data layer)


### PR DESCRIPTION
- Use latest SVGs
- Add intro and outro tip data (for the full page tour, but keeping everything together seems a good idea)
- Stop nudging images to the left (as agreed with design)
- Include tour files in bootstrap (we've been including them in the apps, which was wrong)