### PR TITLE
Add js/no-js classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ For usage information see [the wiki](https://github.com/Financial-Times/n-ui/wik
 
 ## Bower linking
 
-To work with n-ui when it's bower linked into an app you will need to run `make -j2 build run`, which will start a https server on port `3456` and build and watch an n-ui bundle. Your app will need to be on `n-express@17.6.3` or later for this to work.
+To work with n-ui when it's bower linked into an app you will need to run `make -j2 watch run`, which will start a https server on port `3456` and build and watch an n-ui bundle. Your app will need to be on `n-express@17.6.3` or later for this to work.
 
 
 ## **An important note on releases **

--- a/js-setup/templates/ctm.html
+++ b/js-setup/templates/ctm.html
@@ -1,8 +1,13 @@
 {{#if @root.flags.javascript}}
+var classes = document.documentElement.className; {{!note: once we ditch support we can just use classlist}}
+classes = classes.replace(/\bno-js\b/, 'js'); {{!note: needed for JS that's run out of the scope of the bootstrap (inline onclicks, etc)}}
+
 window.cutsTheMustard = (typeof Function.prototype.bind !== 'undefined');
 if (window.cutsTheMustard) {
-	document.documentElement.className = document.documentElement.className.replace(/\bcore\b/, 'enhanced'); {{!note: once we ditch support we can just use classlist}}
+	classes = classes.replace(/\bcore\b/, 'enhanced');
 }
+
+document.documentElement.className = classes;
 {{else}}
 window.cutsTheMustard = false;
 {{/if}}

--- a/utils/main.scss
+++ b/utils/main.scss
@@ -43,6 +43,8 @@
 		height: 1px;
 	}
 
+	.no-js .n-util-hide-no-js,
+	.js .n-util-hide-js,
 	.core .n-util-hide-core,
 	.enhanced .n-util-hide-enhanced {
 		display: none;


### PR DESCRIPTION
Used for JS that runs outside our bootstrap process (e.g. `javscript:` hrefs)