### PR TITLE
Reduce tour tip text margin from 16px to 10px

### DIFF
--- a/tour-tip/main.scss
+++ b/tour-tip/main.scss
@@ -11,7 +11,7 @@
 	}
 
 	.tour-tip__text {
-		margin: $spacing-unit;
+		margin: 10px;
 	}
 
 	.tour-tip__link {


### PR DESCRIPTION
Mostly for the sake of avoiding an override for lining up on stream page