### PR TITLE
Tip tweaks

### DIFF
--- a/tour-tip/main.scss
+++ b/tour-tip/main.scss
@@ -2,10 +2,6 @@
 
 @if nUiApply('tourTip') {
 
-	.tour-tip {
-		color: getColor('cold-1');
-	}
-
 	.tour-tip__main {
 		overflow: hidden;
 	}

--- a/tour-tip/main.scss
+++ b/tour-tip/main.scss
@@ -26,6 +26,7 @@
 
 	.tour-tip__body {
 		@include oTypographySans('m', $load-progressively: true);
+		margin: $spacing-unit 0 0;
 	}
 
 	.tour-tip__body-link {
@@ -80,8 +81,20 @@
 
 			.tour-tip__cta {
 				@include oButtonsSize('big');
-				margin-top: $spacing-unit*0.5;
+				margin-top: $spacing-unit;
 			}
+		}
+
+		.tour-tip--l {
+
+			.tour-tip__body {
+				margin: $spacing-unit * 1.5 0 0;
+			}
+
+			.tour-tip__cta {
+				margin-top: $spacing-unit * 1.5;
+			}
+
 		}
 
 		.tour-tip--reversed {


### PR DESCRIPTION
- Dark tip text to use default body text colour
- Make margins more consistent (but kept them bigger for large tips)

e.g. before
![screen shot 2016-09-28 at 16 26 22](https://cloud.githubusercontent.com/assets/4622378/18920252/b9782386-8598-11e6-9452-501e9a8a364d.png)

after
![screen shot 2016-09-28 at 16 26 31](https://cloud.githubusercontent.com/assets/4622378/18920206/9759afe0-8598-11e6-9f14-ac111673376f.png)
