### PR TITLE
Amend Large ads breakpoint to more closely match o-grid

### DIFF
--- a/ads/js/oAdsConfig.js
+++ b/ads/js/oAdsConfig.js
@@ -78,6 +78,12 @@ module.exports = function (flags, appName, adOptions) {
 				sizes: 'fluid'
 			}
 		},
+		responsive: {
+			extra: [1025, 0], //Reasonable width to show a Billboard (desktop)
+			large: [980, 0], //reasonable width to show SuperLeaderboard (tablet landscape)
+			medium: [760, 0], //reasonable width to show a leaderboard (tablet portrait)
+			small: [0, 0] //Mobile
+		},
 		krux: kruxConfig,
 		collapseEmpty: 'before',
 		dfp_targeting: utils.keyValueString(targeting),


### PR DESCRIPTION
@VladDubrovskis @gvonkoss 

Extend "large" by 20px to more closely match the o-grid breakpoints, and avoid dead spots in article/stream pages that pick up the wrong ad calls.