### PR TITLE
fixing nasty race condition with css loading

### DIFF
--- a/js-setup/js/loader.js
+++ b/js-setup/js/loader.js
@@ -75,7 +75,6 @@ class JsSetup {
 					});
 			};
 		}
-
 		return Promise.resolve({
 			flags: flags,
 			appInfo: this.appInfo,

--- a/js-setup/templates/bootstrapper.html
+++ b/js-setup/templates/bootstrapper.html
@@ -15,22 +15,6 @@
 		return o;
 	};
 
-	window.ftNextFireCondition = function (condition) {
-		var evName = 'ftNext' + condition;
-		if (!window[evName]) {
-			var ev;
-			try {
-				ev = new CustomEvent(evName);
-			// really annoying, but the CSSLoading might occur before polyfilling CustomEvent :(
-			} catch (e) {
-				ev = document.createEvent('CustomEvent')
-				ev.initCustomEvent(evName, false, false, null);
-			}
-			document.dispatchEvent(ev);
-			window[evName] = 1;
-		}
-	};
-
 	{{>n-ui/layout/partials/css-loader}}
 
 	window.{{@root.polyfillCallbackName}} = function () {

--- a/js-setup/templates/fire-condition.html
+++ b/js-setup/templates/fire-condition.html
@@ -1,0 +1,17 @@
+<script>
+window.ftNextFireCondition = function (condition) {
+	var evName = 'ftNext' + condition;
+	if (!window[evName]) {
+		var ev;
+		try {
+			ev = new CustomEvent(evName);
+		// really annoying, but the CSSLoading might occur before polyfilling CustomEvent
+		} catch (e) {
+			ev = document.createEvent('CustomEvent')
+			ev.initCustomEvent(evName, false, false, null);
+		}
+		document.dispatchEvent(ev);
+		window[evName] = 1;
+	}
+};
+</script>

--- a/layout/partials/stylesheets.html
+++ b/layout/partials/stylesheets.html
@@ -7,7 +7,7 @@
 		</style>
 		{{#each @root.cssBundles}}
 			{{#ifAll @root.criticalCss isLazy}}
-				<link rel="preload" href="{{path}}" as="style" onload="this.rel='stylesheet';{{#if isMain}}window.ftNextMainCssLoaded=true{{/if}}">
+				<link rel="preload" href="{{path}}" as="style" onload="this.rel='stylesheet';{{#if isMain}}window.ftNextFireCondition('MainCssLoaded'){{/if}}">
 				<noscript>
 					<link rel="stylesheet" href="{{path}}">
 				</noscript>

--- a/layout/vanilla.html
+++ b/layout/vanilla.html
@@ -12,7 +12,7 @@
 		{{#if setBase}}
 		<base target="_parent" href="{{setBase}}">
 		{{/if}}
-
+		{{>n-ui/js-setup/templates/fire-condition}}
 		{{>n-ui/layout/partials/stylesheets}}
 
 		{{#outputBlock 'head'}}{{/outputBlock}}

--- a/layout/wrapper.html
+++ b/layout/wrapper.html
@@ -28,7 +28,7 @@
 		{{#each preconnect}}
 		<link rel="preconnect" href="{{host}}"{{#if crossorigin}} crossorigin="{{crossorigin}}"{{/if}}>
 		{{/each}}
-
+		{{>n-ui/js-setup/templates/fire-condition}}
 		{{>n-ui/layout/partials/stylesheets}}
 
 		<link rel="icon" type="image/png" href="https://next-geebee.ft.com/assets/brand-ft/icons/v2/favicon-32x32.png" sizes="32x32">

--- a/utils/index.js
+++ b/utils/index.js
@@ -42,9 +42,7 @@ module.exports = {
 		});
 	},
 	waitForCondition: (conditionName, action) => {
-		return window[`ftNext${conditionName}Loaded`] ?
-			action() :
-			document.addEventListener(`ftNext${conditionName}Loaded`, action);
+		window[`ftNext${conditionName}Loaded`] ? action() : document.addEventListener(`ftNext${conditionName}Loaded`, action)
 	},
 	broadcast: (name, data, bubbles = true) => {
 		const rootEl = document.body;


### PR DESCRIPTION
Not sure how long this has been a bug, but probably exacerbated by the fact that the code that initialises the mainCss promise now lives in a shared bundle and is therefore more likely to be cached than the page's css is, which means it loads too quickly for the inline `onload` handler, so having the onload handler just set a flag is no longer enough. I have a sneaking suspicion that possibly Chrome have tweaked the asynchronissity of the onload handler too (previously if the css file was cached it fired immediately, but now it appears to be asynchronous). No time to investigate fully though

The end result being that the mainCss promise often didn't resolve before. This fixes that

@phamann @ironsidevsquincy
