### PR TITLE
Sticky ad 4

### DIFF
--- a/ads/index.js
+++ b/ads/index.js
@@ -32,6 +32,19 @@ function initOAds (flags, appName, adOptions) {
 	});
 }
 
+
+function initStickyHeaderAdvert(flags) {
+	if(flags && flags.get('stickyHeaderAd')) {
+		let stickyAd = new Sticky(
+			document.querySelector('.above-header-advert'),
+			{ 'sibling' : '.header-ad-placeholder__top',
+			'stickUntil' : '#primary-nav #o-header-nav-desktop'
+			});
+		stickyAd.init();
+	}
+}
+
+
 function onAdsComplete (flags, event) {
 	const detail = event.detail;
 	/* istanbul ignore else  */
@@ -45,20 +58,23 @@ function onAdsComplete (flags, event) {
 			detail.slot.reporter = new Reporter(detail.slot);
 		}
 
+
 		if (detail.slot.gpt && detail.slot.gpt.isEmpty === false) {
 			utils.log.info('Ad loaded in slot', event);
 			if (slotsRendered === 0) {
 				perfMark('firstAdLoaded');
-				if (/spoor-id=3/.test(document.cookie)) {
+
 					customTimings.firstAdLoaded = new Date().getTime();
-					const sendTimings = () => {
-						customTimings.adIframeLoaded = new Date().getTime();
-						perfMark('adIframeLoaded');
-						sendMetrics(customTimings, detail.slot);
-						document.body.removeEventListener('oAds.adIframeLoaded', sendTimings);
+					const iframeLoadedCallback = () => {
+						initStickyHeaderAdvert(flags);
+						if (/spoor-id=3/.test(document.cookie)) {
+							customTimings.adIframeLoaded = new Date().getTime();
+							perfMark('adIframeLoaded');
+							sendMetrics(customTimings, detail.slot);
+						}
+						document.body.removeEventListener('oAds.adIframeLoaded', iframeLoadedCallback);
 					}
-					document.body.addEventListener('oAds.adIframeLoaded', sendTimings);
-				}
+					document.body.addEventListener('oAds.adIframeLoaded', iframeLoadedCallback);
 			}
 		} else if (detail.slot.gpt && detail.slot.gpt.isEmpty === true) {
 			utils.log.warn('Failed to load ad, details below');
@@ -84,23 +100,6 @@ module.exports = {
 					if (/(BlackBerry|BBOS|PlayBook|BB10)/.test(navigator.userAgent)) {
 						return;
 					}
-
-					if(flags && flags.get('stickyHeaderAd')) {
-										let stickyAd = new Sticky(
-											document.querySelector('.above-header-advert'),
-											{ 'sibling' : '.header-ad-placeholder__top',
-											'stickUntil' : '#primary-nav .o-header__top'
-											});
-										stickyAd.init();
-									}
-									if(flags && flags.get('stickyRightAd')) {
-										let stickyRight = new Sticky(
-											document.querySelector('.sidebar-advert'),
-											{	'paddingTop' : '70',
-												'stickUntil' : '.article__share--bottom'
-											});
-										stickyRight.init();
-									}
 
 					return Promise.resolve()
 						.then(() => {

--- a/ads/index.js
+++ b/ads/index.js
@@ -35,7 +35,11 @@ function initOAds (flags, appName, adOptions) {
 
 function initStickyHeaderAdvert (flags) {
 	if(flags && flags.get('stickyHeaderAd')) {
-		let stickyAd = new Sticky( document.querySelector('.above-header-advert'), { 'sibling' : '.header-ad-placeholder__top', 'stickUntil' : '#primary-nav #o-header-nav-desktop'});
+		let stickyAd = new Sticky(
+			document.querySelector('.above-header-advert'),
+			document.querySelector('.header-ad-placeholder__top'),
+			document.querySelector('#primary-nav #o-header-nav-desktop')
+		);
 		stickyAd.init();
 	}
 }

--- a/ads/index.js
+++ b/ads/index.js
@@ -33,17 +33,12 @@ function initOAds (flags, appName, adOptions) {
 }
 
 
-function initStickyHeaderAdvert(flags) {
+function initStickyHeaderAdvert (flags) {
 	if(flags && flags.get('stickyHeaderAd')) {
-		let stickyAd = new Sticky(
-			document.querySelector('.above-header-advert'),
-			{ 'sibling' : '.header-ad-placeholder__top',
-			'stickUntil' : '#primary-nav #o-header-nav-desktop'
-			});
+		let stickyAd = new Sticky( document.querySelector('.above-header-advert'), { 'sibling' : '.header-ad-placeholder__top', 'stickUntil' : '#primary-nav #o-header-nav-desktop'});
 		stickyAd.init();
 	}
 }
-
 
 function onAdsComplete (flags, event) {
 	const detail = event.detail;

--- a/ads/js/sticky.js
+++ b/ads/js/sticky.js
@@ -94,7 +94,6 @@ Sticky.prototype.init = function () {
 		return;
 	};
 
-	window.addEventListener('scroll', this.eventScrollStart);
 	const fixedElementTopPosition = this.fixed.getBoundingClientRect().top;
 	this.fixed.style.zIndex = '23';
 	this.fixed.style.top = `${fixedElementTopPosition}px`;
@@ -110,10 +109,13 @@ Sticky.prototype.init = function () {
 		this.sibling.style.marginTop = `${this.fixed.offsetHeight}px`;
 	}
 
+	window.addEventListener('scroll', this.eventScrollStart);
+
 	const cookieCloseButton = document.querySelector('.o-cookie-message__close-btn');
 	if (cookieCloseButton) {
 		let cookieCloseEvent = cookieCloseButton.addEventListener('click', function () {
 			this.extraHeight = 0;
+			this.boundaryTop = this.boundary.getBoundingClientRect().top;
 			this.reset();
 			cookieCloseButton.removeEventListener('click', cookieCloseEvent)
 		}.bind(this));

--- a/ads/js/sticky.js
+++ b/ads/js/sticky.js
@@ -1,7 +1,6 @@
 const debounce = require('./utils').debounce;
 
 function Sticky (el, sibling, boundary) {
-	this.opts = opts || {};
 	this.fixed = el;
 	this.boundary = boundary;
 	this.sibling = sibling;
@@ -108,7 +107,7 @@ Sticky.prototype.init = function () {
 
 	const cookieCloseButton = document.querySelector('.o-cookie-message__close-btn');
 	if (cookieCloseButton) {
-		let cookieCloseEvent = cookieCloseButton.addEventListener('click', function () {
+		const cookieCloseEvent = cookieCloseButton.addEventListener('click', function () {
 			this.extraHeight = 0;
 			this.boundaryTop = this.boundary.getBoundingClientRect().top;
 			this.reset();

--- a/ads/js/sticky.js
+++ b/ads/js/sticky.js
@@ -1,111 +1,124 @@
 const debounce = require('./utils').debounce;
 const stickyNavHeight = 74; // for use with Right Hand Rail
 
-function Sticky (el, opts) {
-	if (!el) return;
-	this.el = el;
-	this.opts = opts || {};
+function Sticky(el, opts) {
+	debugger;
+  this.opts = opts || {};
+  this.fixed = el;
+  this.boundary = document.querySelector(this.opts.stickUntil);
+  this.eventdbScrollEnd = this.debounce(this.scrollEnd.bind(this), 300);
+  this.eventScrollStart = this.scrollStart.bind(this);
 	this.sibling = opts.sibling ? document.querySelector(opts.sibling) : null;
-	this.stickUntil = document.querySelector(opts.stickUntil);
-	this.extraHeight = false;
-	this.cookieMessage = !!document.querySelector('.cookie-message');
-	this.opts.stickWhen = this.el.getBoundingClientRect().top - stickyNavHeight; // for use with RHR
-;}
+	this.extraHeight = 0;
+	this.cookieMessage = document.querySelector('.cookie-message');
 
-// if (this.sibling) {...} conditions based on active sticky RHR — currently enabled for basic demo
-Sticky.prototype.stick = function () {
-	this.el.style.position = 'fixed';
-	this.el.style.top = this.opts.paddingTop || '0';
-	if (this.sibling) { this.sibling.style.marginTop = this.el.offsetHeight + 'px'; }
-};
+  this.animationFrame;
+  this.startScroll;
+  this.boundaryTop;
+  this.fixedHeight;
+}
 
-Sticky.prototype.unstick = function () {
-	this.el.style.position = 'absolute';
-	if (this.sibling) {
-		this.el.style.top = this.releasePoint + 'px';
-		this.sibling.style.marginTop = this.el.offsetHeight + 'px';
-	} else {
-		this.el.style.top = (this.releasePoint - this.el.offsetHeight) + 'px';
+
+Sticky.prototype.debounce = function (cb, wait) {
+	let timeout;
+	return function () {
+    clearTimeout(timeout);
+		timeout = setTimeout(cb, wait);
 	}
-};
-
-Sticky.prototype.onScroll = function () {
-	if (this.sibling) {
-		if (this.cookieMessage && document.querySelector('.cookie-message--hidden')){
-			this.opts.stickWhen = 0
-			this.releasePoint -= 35
-			this.cookieMessage = false
-		} else if (this.cookieMessage) {
-			this.opts.stickWhen = 35
-		} else {
-			this.opts.stickWhen = 0
-		}
-	}
-
-	if (!this.extraHeight && document.querySelector('.visible .n-header__marketing-promo__container')) {
-		this.releasePoint += 50;
-		this.extraHeight = true
-	}
-
-	let breakPoint;
-	let viewportOffset = window.pageYOffset || window.scrollY
-	this.sibling ? breakPoint = this.releasePoint : breakPoint = this.releasePoint + 144
-
-	if((breakPoint > viewportOffset) && (viewportOffset >= this.opts.stickWhen)) {
-		requestAnimationFrame(this.stick.bind(this));
-	} else if (breakPoint < viewportOffset) {
-		requestAnimationFrame(this.unstick.bind(this));
-	} else if (viewportOffset <= this.opts.stickWhen) {
-		this.reset();
-	}
-};
+}
 
 Sticky.prototype.startLoop = function () {
-	this.lastAnimationFrame = window.requestAnimationFrame(() => {
-		this.onScroll();
-		this.startLoop();
-	})
-};
+  this.animationFrame = window.requestAnimationFrame(() => {
+    const atBoundary = (window.scrollY - this.startScroll + this.fixedHeight) >= this.boundaryTop;
+    const isAbsolute = this.fixed.style.position === 'absolute';
+		const extraAbsolute = ((window.scrollY - this.extraHeight) >= 0);
 
-Sticky.prototype.stopLoop = function () {
-	this.lastAnimationFrame && window.cancelAnimationFrame(this.lastAnimationFrame);
-};
+    if ((atBoundary && !isAbsolute)) {
+      this.fixed.style.position = 'absolute';
+      this.fixed.style.top = this.startScroll + this.boundaryTop - this.fixedHeight + 'px';
+    }
 
-Sticky.prototype.bindScroll = function () {
-	window.removeEventListener('scroll', this.bindScroll);
-	window.addEventListener('scroll', this.debouncedScroll)
-	this.startLoop()
-};
+    if (!atBoundary && isAbsolute && extraAbsolute) {
+			if(extraAbsolute) {
+	      this.fixed.style.position = 'fixed';
+	      this.fixed.style.top = '0px';
+				if (this.sibling) {
+					this.sibling.style.marginTop = this.fixedHeight  + 'px';
+				}
+			}
+    }
 
-Sticky.prototype.unbindScroll = function () {
-	this.stopLoop()
-	window.removeEventListener('scroll', this.debouncedScroll)
-	window.addEventListener('scroll', this.bindScroll)
-};
+		if(!extraAbsolute && !isAbsolute) {
+			this.reset();
+		}
 
-Sticky.prototype.onResize = function () {
-	if(this.onScrollListener && this.el.offsetHeight < 10) {
-		this.unbindScroll();
-	} else if (!this.onScrollListener && this.el.offsetHeight >= 10) {
-		this.bindScroll();
-	}
-	this.releasePoint = (this.stickUntil.offsetTop + this.stickUntil.offsetHeight - this.el.offsetHeight);
-};
+    this.startLoop();
+  });
+}
 
 Sticky.prototype.reset = function () {
-	this.el.style.position = 'static';
-	this.sibling ? this.sibling.style.marginTop = '0px' : this.sibling;
-};
+	this.fixed.style.position = 'absolute';
+	this.fixed.style.top = this.extraHeight + 'px';
+}
+
+Sticky.prototype.endLoop = function () {
+  window.cancelAnimationFrame(this.animationFrame);
+}
+
+Sticky.prototype.scrollStart = function () {
+  window.removeEventListener('scroll', this.eventScrollStart);
+  window.addEventListener('scroll', this.eventdbScrollEnd)
+
+  // only do this work once
+  this.fixedHeight = this.fixed.offsetHeight;
+  this.startScroll = window.pageYOffset;
+  this.boundaryTop = this.boundary.getBoundingClientRect().top;
+
+	if (this.sibling && this.sibling.style.marginTop !== this.fixedHeight + 'px') {
+		this.sibling.style.marginTop = this.fixedHeight + 'px';
+	}
+
+  this.startLoop();
+}
+
+
+Sticky.prototype.scrollEnd = function () {
+  this.endLoop();
+  window.removeEventListener('scroll', this.eventdbScrollEnd);
+  window.addEventListener('scroll', this.eventScrollStart);
+}
+
+
 
 Sticky.prototype.init = function () {
-	if(!this.el || window.pageYOffset > 0 || window.scrollY > 0) {
+	if(!this.fixed || window.pageYOffset > 0 || window.scrollY > 0) {
 		return;
 	};
-	this.releasePoint = (this.stickUntil.offsetTop + this.stickUntil.offsetHeight - this.el.offsetHeight);
-	this.el.style.zIndex = '23';
 
-	window.addEventListener('resize', debounce(this.onResize).bind(this));
-	window.addEventListener('scroll', this.bindScroll());
-};
+  window.addEventListener('scroll', this.eventScrollStart);
+	const fixedElementTopPosition = this.fixed.getBoundingClientRect().top;
+  this.fixed.style.zIndex = '23';
+  this.fixed.style.top = fixedElementTopPosition + 'px';
+
+	if(fixedElementTopPosition > 0) {
+		this.extraHeight = fixedElementTopPosition;
+		this.fixed.style.position = 'absolute';
+	} else {
+		this.fixed.style.position = 'fixed';
+	}
+
+	if (this.sibling) {
+		this.sibling.style.marginTop = this.fixed.offsetHeight + 'px';
+	}
+
+	const cookieCloseButton = document.querySelector('.o-cookie-message__close-btn');
+	if(cookieCloseButton) {
+		let cookieCloseEvent = cookieCloseButton.addEventListener('click', function(){
+			this.extraHeight = 0;
+			this.reset();
+			cookieCloseButton.removeEventListener('click', cookieCloseEvent)
+		}.bind(this));
+	}
+}
 
 module.exports = Sticky;

--- a/ads/js/sticky.js
+++ b/ads/js/sticky.js
@@ -16,38 +16,51 @@ function Sticky (el, opts) {
 	this.fixedHeight;
 }
 
+
+
 Sticky.prototype.startLoop = function () {
 	this.animationFrame = window.requestAnimationFrame(() => {
-		const atBoundary = (window.scrollY - this.startScroll + this.fixedHeight) >= this.boundaryTop;
-		const isAbsolute = this.fixed.style.position === 'absolute';
-		const extraAbsolute = ((window.scrollY - this.extraHeight) >= 0);
-
-		if ((atBoundary && !isAbsolute)) {
-			this.fixed.style.position = 'absolute';
-			this.fixed.style.top = this.startScroll + this.boundaryTop - this.fixedHeight + 'px';
-		}
-
-		if (!atBoundary && isAbsolute && extraAbsolute) {
-			if (extraAbsolute) {
-				this.fixed.style.position = 'fixed';
-				this.fixed.style.top = '0px';
-				if (this.sibling) {
-					this.sibling.style.marginTop = this.fixedHeight + 'px';
-				}
-			}
-		}
-
-		if (!extraAbsolute && !isAbsolute) {
-			this.reset();
-		}
-
+		this.calculate();
 		this.startLoop();
 	});
 }
 
+Sticky.prototype.calculate = function() {
+	const scrollY = window.pageYOffset || window.scrollY;
+	const atBoundary = (scrollY - this.startScroll + this.fixedHeight) >= this.boundaryTop;
+	const isAbsolute = this.fixed.style.position === 'absolute';
+	const extraAbsolute = ((scrollY - this.extraHeight) >= 0);
+
+	if ((atBoundary && !isAbsolute)) {
+		this.unstick();
+	}
+
+	if (!atBoundary && isAbsolute && extraAbsolute) {
+		this.stick();
+	}
+
+	if ((!extraAbsolute && !isAbsolute) || (!atBoundary && isAbsolute && !extraAbsolute)) {
+		this.reset();
+	}
+}
+
+Sticky.prototype.stick = function () {
+	this.fixed.style.position = 'fixed';
+	this.fixed.style.top = '0px';
+	if (this.sibling) {
+		this.sibling.style.marginTop = `${this.fixedHeight}px`;
+	}
+}
+
+Sticky.prototype.unstick = function () {
+	this.fixed.style.position = 'absolute';
+	this.fixed.style.top = `${this.startScroll + this.boundaryTop - this.fixedHeight}px`;
+}
+
+
 Sticky.prototype.reset = function () {
 	this.fixed.style.position = 'absolute';
-	this.fixed.style.top = this.extraHeight + 'px';
+	this.fixed.style.top = `${this.extraHeight}px`;
 }
 
 Sticky.prototype.endLoop = function () {
@@ -63,8 +76,8 @@ Sticky.prototype.scrollStart = function () {
 	this.startScroll = window.pageYOffset;
 	this.boundaryTop = this.boundary.getBoundingClientRect().top;
 
-	if (this.sibling && this.sibling.style.marginTop !== this.fixedHeight + 'px') {
-		this.sibling.style.marginTop = this.fixedHeight + 'px';
+	if (this.sibling && this.sibling.style.marginTop !== `${this.fixedHeight}px`) {
+		this.sibling.style.marginTop = `${this.fixedHeight}px`;
 	}
 
 	this.startLoop();

--- a/ads/js/sticky.js
+++ b/ads/js/sticky.js
@@ -25,7 +25,7 @@ Sticky.prototype.startLoop = function () {
 	});
 }
 
-Sticky.prototype.calculate = function() {
+Sticky.prototype.calculate = function () {
 	const scrollY = window.pageYOffset || window.scrollY;
 	const atBoundary = (scrollY - this.startScroll + this.fixedHeight) >= this.boundaryTop;
 	const isAbsolute = this.fixed.style.position === 'absolute';

--- a/ads/js/sticky.js
+++ b/ads/js/sticky.js
@@ -27,17 +27,17 @@ Sticky.prototype.calculate = function () {
 	const scrollY = window.pageYOffset || window.scrollY;
 	const atBoundary = (scrollY - this.startScroll + this.fixedHeight) >= this.boundaryTop;
 	const isAbsolute = this.fixed.style.position === 'absolute';
-	const extraOffsetForAbsolutePosition = ((scrollY - this.extraHeight) >= 0);
+	const canBeFixed = ((scrollY - this.extraHeight) >= 0);
 
 	if ((atBoundary && !isAbsolute)) {
 		this.unstick();
 	}
 
-	if (!atBoundary && isAbsolute && extraOffsetForAbsolutePosition) {
+	if (!atBoundary && isAbsolute && canBeFixed) {
 		this.stick();
 	}
 
-	if ((!extraOffsetForAbsolutePosition && !isAbsolute) || (!atBoundary && isAbsolute && !extraOffsetForAbsolutePosition)) {
+	if ((!canBeFixed && !isAbsolute) || (!atBoundary && isAbsolute && !canBeFixed)) {
 		this.reset();
 	}
 }

--- a/ads/js/sticky.js
+++ b/ads/js/sticky.js
@@ -97,7 +97,7 @@ Sticky.prototype.init = function () {
 	window.addEventListener('scroll', this.eventScrollStart);
 	const fixedElementTopPosition = this.fixed.getBoundingClientRect().top;
 	this.fixed.style.zIndex = '23';
-	this.fixed.style.top = fixedElementTopPosition + 'px';
+	this.fixed.style.top = `${fixedElementTopPosition}px`;
 
 	if (fixedElementTopPosition > 0) {
 		this.extraHeight = fixedElementTopPosition;
@@ -107,7 +107,7 @@ Sticky.prototype.init = function () {
 	}
 
 	if (this.sibling) {
-		this.sibling.style.marginTop = this.fixed.offsetHeight + 'px';
+		this.sibling.style.marginTop = `${this.fixed.offsetHeight}px`;
 	}
 
 	const cookieCloseButton = document.querySelector('.o-cookie-message__close-btn');

--- a/ads/js/sticky.js
+++ b/ads/js/sticky.js
@@ -1,14 +1,13 @@
 const debounce = require('./utils').debounce;
 
-function Sticky (el, opts) {
+function Sticky (el, sibling, boundary) {
 	this.opts = opts || {};
 	this.fixed = el;
-	this.boundary = document.querySelector(this.opts.stickUntil);
+	this.boundary = boundary;
+	this.sibling = sibling;
 	this.eventdbScrollEnd = debounce(this.scrollEnd.bind(this), 300);
 	this.eventScrollStart = this.scrollStart.bind(this);
-	this.sibling = opts.sibling ? document.querySelector(opts.sibling) : null;
 	this.extraHeight = 0;
-	this.cookieMessage = document.querySelector('.cookie-message');
 
 	this.animationFrame;
 	this.startScroll;
@@ -47,9 +46,7 @@ Sticky.prototype.calculate = function () {
 Sticky.prototype.stick = function () {
 	this.fixed.style.position = 'fixed';
 	this.fixed.style.top = '0px';
-	if (this.sibling) {
-		this.sibling.style.marginTop = `${this.fixedHeight}px`;
-	}
+	this.sibling.style.marginTop = `${this.fixedHeight}px`;
 }
 
 Sticky.prototype.unstick = function () {
@@ -76,7 +73,7 @@ Sticky.prototype.scrollStart = function () {
 	this.startScroll = window.pageYOffset;
 	this.boundaryTop = this.boundary.getBoundingClientRect().top;
 
-	if (this.sibling && this.sibling.style.marginTop !== `${this.fixedHeight}px`) {
+	if (this.sibling.style.marginTop !== `${this.fixedHeight}px`) {
 		this.sibling.style.marginTop = `${this.fixedHeight}px`;
 	}
 
@@ -90,13 +87,14 @@ Sticky.prototype.scrollEnd = function () {
 }
 
 Sticky.prototype.init = function () {
-	if (!this.fixed || window.pageYOffset > 0 || window.scrollY > 0) {
+	if (!this.fixed || !this.sibling || !this.boundary || window.pageYOffset > 0 || window.scrollY > 0) {
 		return;
 	};
 
 	const fixedElementTopPosition = this.fixed.getBoundingClientRect().top;
 	this.fixed.style.zIndex = '23';
 	this.fixed.style.top = `${fixedElementTopPosition}px`;
+	this.sibling.style.marginTop = `${this.fixed.offsetHeight}px`;
 
 	if (fixedElementTopPosition > 0) {
 		this.extraHeight = fixedElementTopPosition;
@@ -105,9 +103,6 @@ Sticky.prototype.init = function () {
 		this.fixed.style.position = 'fixed';
 	}
 
-	if (this.sibling) {
-		this.sibling.style.marginTop = `${this.fixed.offsetHeight}px`;
-	}
 
 	window.addEventListener('scroll', this.eventScrollStart);
 

--- a/ads/js/sticky.js
+++ b/ads/js/sticky.js
@@ -27,17 +27,17 @@ Sticky.prototype.calculate = function () {
 	const scrollY = window.pageYOffset || window.scrollY;
 	const atBoundary = (scrollY - this.startScroll + this.fixedHeight) >= this.boundaryTop;
 	const isAbsolute = this.fixed.style.position === 'absolute';
-	const extraAbsolute = ((scrollY - this.extraHeight) >= 0);
+	const extraOffsetForAbsolutePosition = ((scrollY - this.extraHeight) >= 0);
 
 	if ((atBoundary && !isAbsolute)) {
 		this.unstick();
 	}
 
-	if (!atBoundary && isAbsolute && extraAbsolute) {
+	if (!atBoundary && isAbsolute && extraOffsetForAbsolutePosition) {
 		this.stick();
 	}
 
-	if ((!extraAbsolute && !isAbsolute) || (!atBoundary && isAbsolute && !extraAbsolute)) {
+	if ((!extraOffsetForAbsolutePosition && !isAbsolute) || (!atBoundary && isAbsolute && !extraOffsetForAbsolutePosition)) {
 		this.reset();
 	}
 }

--- a/ads/js/sticky.js
+++ b/ads/js/sticky.js
@@ -1,59 +1,48 @@
 const debounce = require('./utils').debounce;
-const stickyNavHeight = 74; // for use with Right Hand Rail
 
-function Sticky(el, opts) {
-	debugger;
-  this.opts = opts || {};
-  this.fixed = el;
-  this.boundary = document.querySelector(this.opts.stickUntil);
-  this.eventdbScrollEnd = this.debounce(this.scrollEnd.bind(this), 300);
-  this.eventScrollStart = this.scrollStart.bind(this);
+function Sticky (el, opts) {
+	this.opts = opts || {};
+	this.fixed = el;
+	this.boundary = document.querySelector(this.opts.stickUntil);
+	this.eventdbScrollEnd = debounce(this.scrollEnd.bind(this), 300);
+	this.eventScrollStart = this.scrollStart.bind(this);
 	this.sibling = opts.sibling ? document.querySelector(opts.sibling) : null;
 	this.extraHeight = 0;
 	this.cookieMessage = document.querySelector('.cookie-message');
 
-  this.animationFrame;
-  this.startScroll;
-  this.boundaryTop;
-  this.fixedHeight;
-}
-
-
-Sticky.prototype.debounce = function (cb, wait) {
-	let timeout;
-	return function () {
-    clearTimeout(timeout);
-		timeout = setTimeout(cb, wait);
-	}
+	this.animationFrame;
+	this.startScroll;
+	this.boundaryTop;
+	this.fixedHeight;
 }
 
 Sticky.prototype.startLoop = function () {
-  this.animationFrame = window.requestAnimationFrame(() => {
-    const atBoundary = (window.scrollY - this.startScroll + this.fixedHeight) >= this.boundaryTop;
-    const isAbsolute = this.fixed.style.position === 'absolute';
+	this.animationFrame = window.requestAnimationFrame(() => {
+		const atBoundary = (window.scrollY - this.startScroll + this.fixedHeight) >= this.boundaryTop;
+		const isAbsolute = this.fixed.style.position === 'absolute';
 		const extraAbsolute = ((window.scrollY - this.extraHeight) >= 0);
 
-    if ((atBoundary && !isAbsolute)) {
-      this.fixed.style.position = 'absolute';
-      this.fixed.style.top = this.startScroll + this.boundaryTop - this.fixedHeight + 'px';
-    }
+		if ((atBoundary && !isAbsolute)) {
+			this.fixed.style.position = 'absolute';
+			this.fixed.style.top = this.startScroll + this.boundaryTop - this.fixedHeight + 'px';
+		}
 
-    if (!atBoundary && isAbsolute && extraAbsolute) {
-			if(extraAbsolute) {
-	      this.fixed.style.position = 'fixed';
-	      this.fixed.style.top = '0px';
+		if (!atBoundary && isAbsolute && extraAbsolute) {
+			if (extraAbsolute) {
+				this.fixed.style.position = 'fixed';
+				this.fixed.style.top = '0px';
 				if (this.sibling) {
-					this.sibling.style.marginTop = this.fixedHeight  + 'px';
+					this.sibling.style.marginTop = this.fixedHeight + 'px';
 				}
 			}
-    }
+		}
 
-		if(!extraAbsolute && !isAbsolute) {
+		if (!extraAbsolute && !isAbsolute) {
 			this.reset();
 		}
 
-    this.startLoop();
-  });
+		this.startLoop();
+	});
 }
 
 Sticky.prototype.reset = function () {
@@ -62,45 +51,42 @@ Sticky.prototype.reset = function () {
 }
 
 Sticky.prototype.endLoop = function () {
-  window.cancelAnimationFrame(this.animationFrame);
+	window.cancelAnimationFrame(this.animationFrame);
 }
 
 Sticky.prototype.scrollStart = function () {
-  window.removeEventListener('scroll', this.eventScrollStart);
-  window.addEventListener('scroll', this.eventdbScrollEnd)
+	window.removeEventListener('scroll', this.eventScrollStart);
+	window.addEventListener('scroll', this.eventdbScrollEnd)
 
-  // only do this work once
-  this.fixedHeight = this.fixed.offsetHeight;
-  this.startScroll = window.pageYOffset;
-  this.boundaryTop = this.boundary.getBoundingClientRect().top;
+	// only do this work once
+	this.fixedHeight = this.fixed.offsetHeight;
+	this.startScroll = window.pageYOffset;
+	this.boundaryTop = this.boundary.getBoundingClientRect().top;
 
 	if (this.sibling && this.sibling.style.marginTop !== this.fixedHeight + 'px') {
 		this.sibling.style.marginTop = this.fixedHeight + 'px';
 	}
 
-  this.startLoop();
+	this.startLoop();
 }
-
 
 Sticky.prototype.scrollEnd = function () {
-  this.endLoop();
-  window.removeEventListener('scroll', this.eventdbScrollEnd);
-  window.addEventListener('scroll', this.eventScrollStart);
+	this.endLoop();
+	window.removeEventListener('scroll', this.eventdbScrollEnd);
+	window.addEventListener('scroll', this.eventScrollStart);
 }
 
-
-
 Sticky.prototype.init = function () {
-	if(!this.fixed || window.pageYOffset > 0 || window.scrollY > 0) {
+	if (!this.fixed || window.pageYOffset > 0 || window.scrollY > 0) {
 		return;
 	};
 
-  window.addEventListener('scroll', this.eventScrollStart);
+	window.addEventListener('scroll', this.eventScrollStart);
 	const fixedElementTopPosition = this.fixed.getBoundingClientRect().top;
-  this.fixed.style.zIndex = '23';
-  this.fixed.style.top = fixedElementTopPosition + 'px';
+	this.fixed.style.zIndex = '23';
+	this.fixed.style.top = fixedElementTopPosition + 'px';
 
-	if(fixedElementTopPosition > 0) {
+	if (fixedElementTopPosition > 0) {
 		this.extraHeight = fixedElementTopPosition;
 		this.fixed.style.position = 'absolute';
 	} else {
@@ -112,8 +98,8 @@ Sticky.prototype.init = function () {
 	}
 
 	const cookieCloseButton = document.querySelector('.o-cookie-message__close-btn');
-	if(cookieCloseButton) {
-		let cookieCloseEvent = cookieCloseButton.addEventListener('click', function(){
+	if (cookieCloseButton) {
+		let cookieCloseEvent = cookieCloseButton.addEventListener('click', function () {
 			this.extraHeight = 0;
 			this.reset();
 			cookieCloseButton.removeEventListener('click', cookieCloseEvent)


### PR DESCRIPTION
**Changes:**

1. Removed all the right hand rail stickiness just to keep it simple
2. The sticky ads inits once the ad is being loaded on the page, that way we let it expand first. We could test if this works for now and see if it actually has got any extra view ability impact. And if its too low could improve it then?
3. IE is not ideal and sometimes still hover the menu a little but only for a split second.

Very similar to the original solution, just tidied up the event listeners and references

/cc @adgad @andrewgeorgiou1981 @gvonkoss 