### PR TITLE
pa11y setup

### DIFF
--- a/.pa11yci.js
+++ b/.pa11yci.js
@@ -1,17 +1,38 @@
 module.exports = {
-	"defaults": {
-		"timeout": 1000,
-		"page": {
-			"viewport": {
-				"width": 320,
-				"height": 480
-			}
-		}
-	},
 	"urls": [
 		{
 			"url": "https://n-ui.ft.com/n-ui/test-page/" + process.env.CIRCLE_BUILD_NUM + "/test-page.html",
 			"timeout": 10000
+		},
+		{
+			"url": "https://n-ui.ft.com/n-ui/test-page/" + process.env.CIRCLE_BUILD_NUM + "/test-page.html",
+			"timeout": 10000,
+			"page": {
+				"viewport": {
+					"width": 768,
+					"height": 1024
+				}
+			}
+		},
+		{
+			"url": "https://n-ui.ft.com/n-ui/test-page/" + process.env.CIRCLE_BUILD_NUM + "/test-page.html",
+			"timeout": 10000,
+			"page": {
+				"viewport": {
+					"width": 490,
+					"height": 732
+				}
+			}
+		},
+		{
+			"url": "https://n-ui.ft.com/n-ui/test-page/" + process.env.CIRCLE_BUILD_NUM + "/test-page.html",
+			"timeout": 10000,
+			"page": {
+				"viewport": {
+					"width": 320,
+					"height": 480
+				}
+			}
 		}
 	]
 }

--- a/.pa11yci.js
+++ b/.pa11yci.js
@@ -1,0 +1,17 @@
+module.exports = {
+	"defaults": {
+		"timeout": 1000,
+		"page": {
+			"viewport": {
+				"width": 320,
+				"height": 480
+			}
+		}
+	},
+	"urls": [
+		{
+			"url": "https://n-ui.ft.com/n-ui/test-page/" + process.env.CIRCLE_BUILD_NUM + "/test-page.html",
+			"timeout": 10000
+		}
+	]
+}

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ serve:
 nightwatch:
 	nht nightwatch test/js-success.nightwatch.js
 
-test: verify test-unit test-build serve nightwatch
+test: verify test-unit test-build serve pa11y-ci nightwatch
 
 test-dev: verify test-unit-dev
 
@@ -42,3 +42,8 @@ run:
 	@if [ ! -f key.pem ]; then (echo $(MSG_N_UI_CERT) && exit 1); fi
 	@if [ ! -f key-cert.pem ]; then (echo $(MSG_N_UI_CERT) && exit 1); fi
 	http-server dist -p 3456 -c-1 --ssl --cert ./key-cert.pem --key ./key.pem
+
+
+# Test a11y locally
+a11y:
+	pa11y-ci

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,10 @@ serve:
 nightwatch:
 	nht nightwatch test/js-success.nightwatch.js
 
-test: verify test-unit test-build serve pa11y-ci nightwatch
+test: verify test-unit test-build serve a11y nightwatch
+
+a11y:
+	pa11y-ci
 
 test-dev: verify test-unit-dev
 
@@ -42,8 +45,3 @@ run:
 	@if [ ! -f key.pem ]; then (echo $(MSG_N_UI_CERT) && exit 1); fi
 	@if [ ! -f key-cert.pem ]; then (echo $(MSG_N_UI_CERT) && exit 1); fi
 	http-server dist -p 3456 -c-1 --ssl --cert ./key-cert.pem --key ./key.pem
-
-
-# Test a11y locally
-a11y:
-	pa11y-ci

--- a/_test-server/app.js
+++ b/_test-server/app.js
@@ -31,6 +31,7 @@ app.get('/', (req, res) => {
 			return bundle;
 		});
 	res.render('default', {
+		title: 'Test App',
 		layout: 'wrapper'
 	});
 });

--- a/_test-server/views/default.html
+++ b/_test-server/views/default.html
@@ -1,34 +1,36 @@
-<p>lorem ipsum dolor sit down and listen to some latin</p>
-<p>lorem ipsum dolor sit down and listen to some latin</p>
-<p>lorem ipsum dolor sit down and listen to some latin</p>
-<p>lorem ipsum dolor sit down and listen to some latin</p>
-<p>lorem ipsum dolor sit down and listen to some latin</p>
-<p>lorem ipsum dolor sit down and listen to some latin</p>
-<p>lorem ipsum dolor sit down and listen to some latin</p>
-<p>lorem ipsum dolor sit down and listen to some latin</p>
-<p>lorem ipsum dolor sit down and listen to some latin</p>
-<p>lorem ipsum dolor sit down and listen to some latin</p>
-<p>lorem ipsum dolor sit down and listen to some latin</p>
-<p>lorem ipsum dolor sit down and listen to some latin</p>
-<p>lorem ipsum dolor sit down and listen to some latin</p>
-<p>lorem ipsum dolor sit down and listen to some latin</p>
-<p>lorem ipsum dolor sit down and listen to some latin</p>
-<p>lorem ipsum dolor sit down and listen to some latin</p>
-<p>lorem ipsum dolor sit down and listen to some latin</p>
-<p>lorem ipsum dolor sit down and listen to some latin</p>
-<p>lorem ipsum dolor sit down and listen to some latin</p>
-<p>lorem ipsum dolor sit down and listen to some latin</p>
-<p>lorem ipsum dolor sit down and listen to some latin</p>
-<p>lorem ipsum dolor sit down and listen to some latin</p>
-<p>lorem ipsum dolor sit down and listen to some latin</p>
-<p>lorem ipsum dolor sit down and listen to some latin</p>
-<p>lorem ipsum dolor sit down and listen to some latin</p>
-<p>lorem ipsum dolor sit down and listen to some latin</p>
-<p>lorem ipsum dolor sit down and listen to some latin</p>
-<p>lorem ipsum dolor sit down and listen to some latin</p>
-<p>lorem ipsum dolor sit down and listen to some latin</p>
-<p>lorem ipsum dolor sit down and listen to some latin</p>
-<p>lorem ipsum dolor sit down and listen to some latin</p>
-<p>lorem ipsum dolor sit down and listen to some latin</p>
-<p>lorem ipsum dolor sit down and listen to some latin</p>
-<p>lorem ipsum dolor sit down and listen to some latin</p>
+<div id="site-content">
+	<p>lorem ipsum dolor sit down and listen to some latin</p>
+	<p>lorem ipsum dolor sit down and listen to some latin</p>
+	<p>lorem ipsum dolor sit down and listen to some latin</p>
+	<p>lorem ipsum dolor sit down and listen to some latin</p>
+	<p>lorem ipsum dolor sit down and listen to some latin</p>
+	<p>lorem ipsum dolor sit down and listen to some latin</p>
+	<p>lorem ipsum dolor sit down and listen to some latin</p>
+	<p>lorem ipsum dolor sit down and listen to some latin</p>
+	<p>lorem ipsum dolor sit down and listen to some latin</p>
+	<p>lorem ipsum dolor sit down and listen to some latin</p>
+	<p>lorem ipsum dolor sit down and listen to some latin</p>
+	<p>lorem ipsum dolor sit down and listen to some latin</p>
+	<p>lorem ipsum dolor sit down and listen to some latin</p>
+	<p>lorem ipsum dolor sit down and listen to some latin</p>
+	<p>lorem ipsum dolor sit down and listen to some latin</p>
+	<p>lorem ipsum dolor sit down and listen to some latin</p>
+	<p>lorem ipsum dolor sit down and listen to some latin</p>
+	<p>lorem ipsum dolor sit down and listen to some latin</p>
+	<p>lorem ipsum dolor sit down and listen to some latin</p>
+	<p>lorem ipsum dolor sit down and listen to some latin</p>
+	<p>lorem ipsum dolor sit down and listen to some latin</p>
+	<p>lorem ipsum dolor sit down and listen to some latin</p>
+	<p>lorem ipsum dolor sit down and listen to some latin</p>
+	<p>lorem ipsum dolor sit down and listen to some latin</p>
+	<p>lorem ipsum dolor sit down and listen to some latin</p>
+	<p>lorem ipsum dolor sit down and listen to some latin</p>
+	<p>lorem ipsum dolor sit down and listen to some latin</p>
+	<p>lorem ipsum dolor sit down and listen to some latin</p>
+	<p>lorem ipsum dolor sit down and listen to some latin</p>
+	<p>lorem ipsum dolor sit down and listen to some latin</p>
+	<p>lorem ipsum dolor sit down and listen to some latin</p>
+	<p>lorem ipsum dolor sit down and listen to some latin</p>
+	<p>lorem ipsum dolor sit down and listen to some latin</p>
+	<p>lorem ipsum dolor sit down and listen to some latin</p>
+</div>

--- a/ads/test/fixtures/layout-config.js
+++ b/ads/test/fixtures/layout-config.js
@@ -49,6 +49,6 @@ module.exports = {
 					}
 				}
 			]
-		},
+		}
 	}
 };

--- a/header/partials/header/search.html
+++ b/header/partials/header/search.html
@@ -1,8 +1,8 @@
 <div id="o-header-search-{{context}}" class="o-header__row o-header__search o-header__search--{{context}}" data-trackable="header-search" data-o-header-search>
 	<div class="o-header__container">
 		<form class="o-header__search-form" action="/search" role="search" aria-label="Site search" data-typeahead>
-			<label class="o-header__visually-hidden" for="o-header-search-term">Search the <abbr title="Financial Times">FT</abbr></label>
-			<input class="o-header__search-term" id="o-header-search-term" name="q" type="text" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" data-trackable="search-term" placeholder="Search the FT">
+			<label class="o-header__visually-hidden" for="o-header-search-term-{{context}}">Search the <abbr title="Financial Times">FT</abbr></label>
+			<input class="o-header__search-term" id="o-header-search-term-{{context}}" name="q" type="text" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" data-trackable="search-term" placeholder="Search the FT">
 			<button class="o-header__search-submit" type="submit" data-trackable="search-submit">
 				Search
 			</button>

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "node-sass": "^3.8.0",
     "nodemon": "^1.9.2",
     "npm-prepublish": "^1.2.1",
+    "pa11y-ci": "^0.3.0",
     "postcss-loader": "^0.9.1",
     "pre-git": "^3.10.0",
     "sass-loader": "^3.2.0",

--- a/welcome-message/banner.html
+++ b/welcome-message/banner.html
@@ -17,7 +17,7 @@
 		</div>
 		{{!-- button must be present in the HTML as a requirement/limitation of o-expander --}}
 		<div class="n-welcome-banner__column">
-			<button data-trackable="toggled" data-action="welcome-banner-close" name="welcome-banner-close" class="n-welcome-banner__button--close o-if-js if-fixed"></button>
+			<button data-trackable="toggled" data-action="welcome-banner-close" title="Close welcome banner" class="n-welcome-banner__button--close o-if-js if-fixed"></button>
 		</div>
 	{{else}}
 		<h6 class="n-welcome-banner__heading n-welcome-banner__heading--minimized n-welcome-banner__column">Need some help?</h6>
@@ -38,7 +38,7 @@
 		</div>
 		{{!-- button must be present in the HTML as a requirement/limitation of o-expander --}}
 		<div class="n-welcome-banner__column">
-			<button data-trackable="toggled"  name="welcome-banner-close" class="n-welcome-banner__button--toggler o-if-js if-fixed"></button>
+			<button data-trackable="toggled"  title="Close welcome banner" class="n-welcome-banner__button--toggler o-if-js if-fixed"></button>
 		</div>
 	{{/if}}
 </div>

--- a/welcome-message/banner.html
+++ b/welcome-message/banner.html
@@ -17,7 +17,7 @@
 		</div>
 		{{!-- button must be present in the HTML as a requirement/limitation of o-expander --}}
 		<div class="n-welcome-banner__column">
-			<button data-trackable="toggled" data-action="welcome-banner-close" class="n-welcome-banner__button--close o-if-js if-fixed"></button>
+			<button data-trackable="toggled" data-action="welcome-banner-close" name="welcome-banner-close" class="n-welcome-banner__button--close o-if-js if-fixed"></button>
 		</div>
 	{{else}}
 		<h6 class="n-welcome-banner__heading n-welcome-banner__heading--minimized n-welcome-banner__column">Need some help?</h6>
@@ -38,7 +38,7 @@
 		</div>
 		{{!-- button must be present in the HTML as a requirement/limitation of o-expander --}}
 		<div class="n-welcome-banner__column">
-			<button data-trackable="toggled" class="n-welcome-banner__button--toggler o-if-js if-fixed"></button>
+			<button data-trackable="toggled"  name="welcome-banner-close" class="n-welcome-banner__button--toggler o-if-js if-fixed"></button>
 		</div>
 	{{/if}}
 </div>


### PR DESCRIPTION
@leggsimon @aintgoin2goa `o-header-search-term` was a duplicate id which was breaking a11y tests. Would you mind looking over https://github.com/Financial-Times/n-ui/pull/553/files#diff-f0927248e9f4776d64eb2e13cce4e165R5 to see if this would have an effect elsewhere? I don't see this id being used in js code, but I'm not very familiar with the header.

@wheresrhys this covers the basics. Will look into adding other modules if necessary in a separate PR.

cc @pixelandpage this will help catch a11y errors that are common to all the user-facing apps. 