### PR TITLE
Firefox bug on promo

### DIFF
--- a/ads/index.js
+++ b/ads/index.js
@@ -35,10 +35,10 @@ function initOAds (flags, appName, adOptions) {
 
 function initStickyHeaderAdvert (flags) {
 	if(flags && flags.get('stickyHeaderAd')) {
-		let stickyAd = new Sticky(
-			document.querySelector('.above-header-advert'),
+		const stickyAd = new Sticky(
+			document.querySelector('[data-sticky-ad]'),
 			document.querySelector('.header-ad-placeholder__top'),
-			document.querySelector('#primary-nav #o-header-nav-desktop')
+			document.querySelector('.o-header__row.o-header__top')
 		);
 		stickyAd.init();
 	}

--- a/bower.json
+++ b/bower.json
@@ -26,7 +26,7 @@
     "n-service-worker": "^1.4.2",
     "n-sliding-popup": "^1.0.0",
     "next-myft-client": "^6.4.2",
-    "o-ads": "6.0.0-beta.6",
+    "o-ads": "6.0.0-beta.7",
     "o-buttons": "^4.0.1",
     "o-colors": "^3.3.2",
     "o-cookie-message": "^2.0.0",

--- a/js-setup/js/component-initializer.js
+++ b/js-setup/js/component-initializer.js
@@ -111,7 +111,6 @@ export class ComponentInitializer {
 					clientOpts.push({relationship: 'saved', type: 'content'});
 				}
 				myft.client.init(clientOpts);
-
 				this.initializedFeatures.myftClient = true
 			}
 

--- a/myft-digest-promo/main.scss
+++ b/myft-digest-promo/main.scss
@@ -37,6 +37,8 @@
 		right: 0;
 		background-color: transparent;
 		border-color: transparent;
+		height: 22px;
+		width: 22px;
 
 		&::before {
 			@include oIconsGetIcon('cross-disk', getColor('grey-tint5'), 20);


### PR DESCRIPTION
Increases the size of the dismiss btn element to ensure that the clickable area maps to the size of the dismiss icon on all browsers. 

<img width="946" alt="screen shot 2016-10-11 at 14 23 16" src="https://cloud.githubusercontent.com/assets/17549437/19271854/4cd1e53e-8fbe-11e6-9173-8c69c08233cb.png">
