### PR TITLE
fixing clickable area bug

### DIFF
--- a/myft-digest-promo/main.scss
+++ b/myft-digest-promo/main.scss
@@ -37,6 +37,8 @@
 		right: 0;
 		background-color: transparent;
 		border-color: transparent;
+		height: 22px;
+		width: 22px;
 
 		&::before {
 			@include oIconsGetIcon('cross-disk', getColor('grey-tint5'), 20);


### PR DESCRIPTION
Updates the clickable area in the dismiss button element so that it always maps to the space taken up by the dismiss icon. 
<img width="946" alt="screen shot 2016-10-11 at 14 23 16" src="https://cloud.githubusercontent.com/assets/17549437/19273605/f7fa96e4-8fc4-11e6-8396-ea08f27ccfbc.png">
