### PR TITLE
Revert welcome message to non-sticky variant

### DIFF
--- a/welcome-message/template.html
+++ b/welcome-message/template.html
@@ -8,9 +8,6 @@
 	</div>
 </div>
 
-{{!-- supporting 3 different banner versions --}}
-
-
 {{#unless @root.flags.nextFtTour}}
 	<div class="n-welcome-message n-welcome-message--fixed" data-trackable="welcome" hidden>
 		<div class="o-grid-container">
@@ -20,17 +17,4 @@
 			<span class="n-util-visually-hidden">Close</span>
 		</button>
 	</div>
-{{else}}
-	{{#if @root.flags.nextWelcomeCloses}}
-		{{#if anon.userIsLoggedIn}}
-		{{!-- no sticky footer for anon users --}}
-			<div data-component="welcome-banner" class="n-welcome-banner n-welcome-message--fixed" data-trackable="welcome" hidden>
-				{{>n-ui/welcome-message/banner}}
-			</div>
-		{{/if}}
-	{{else}}
-		<div data-o-component="o-expander" data-component="welcome-banner" data-o-expander-shrink-to="hidden" data-o-expander-toggle-selector=".n-welcome-banner__button--toggler" class="o-expander n-welcome-banner n-welcome-message--fixed" data-trackable="welcome" hidden>
-			{{>n-ui/welcome-message/banner}}
-		</div>
-	{{/if}}
 {{/unless}}


### PR DESCRIPTION
Now that launch week is over it is a UX decision that we no longer need the in-your-face sticky version of the welcome message.

**Note:**
I purposefully _haven't_ removed the underlying JS and templates as we may want to re-introduce in the near future for onboarding/anon journeys.