### PR TITLE
Refactor the subscription prompt to accommodate new US elec offer

### DIFF
--- a/js-setup/js/component-initializer.js
+++ b/js-setup/js/component-initializer.js
@@ -6,7 +6,7 @@ import header from '../../header';
 import optOut from '../../opt-out';
 import cookieMessage from '../../cookie-message';
 import welcomeMessage from '../../welcome-message';
-import { init as subscriptionOfferPrompt } from '../../subscription-offer-prompt';
+import subscriptionOfferPrompt from '../../subscription-offer-prompt';
 import footer from '../../footer';
 import myft from '../../myft';
 import digestPromo from '../../myft-digest-promo';
@@ -154,7 +154,7 @@ export class ComponentInitializer {
 					}
 
 					if (config.features.subscriptionOfferPrompt && !this.initializedFeatures.subscriptionOfferPrompt) {
-						flags.get('b2cMessagePrompt') && subscriptionOfferPrompt();
+						subscriptionOfferPrompt(flags);
 						this.initializedFeatures.subscriptionOfferPrompt = true;
 					}
 

--- a/subscription-offer-prompt/index.js
+++ b/subscription-offer-prompt/index.js
@@ -1,148 +1,60 @@
-import SlidingPopup from 'n-sliding-popup';
-import Superstore from 'superstore'
-
 import * as utils from './utils';
-import { broadcast } from '../utils';
+import * as lionel from './lionel';
+import * as election from './us-elections';
 
-const promptLastSeenStorage = new Superstore('local', 'n-ui.subscription-offer-prompt');
-const promptLastSeenStorageKey = 'last-closed';
+/*
+Show the subscription offer prompt.
+There are currently two offers:
+
+ - "The Lionel Slider":
+   - OfferID:
+    * USA: a9582121-87c2-09a7-0cc0-4caf594985d5
+    * All: c1773439-53dc-df3d-9acc-20ce2ecde318
+   - Show if:
+    * the barrier has been seen in this session
+    * browser's' TLS version is > 1.0
+    * this prompt has not been closed, or was last closed more than 30 days ago
+
+ - U.S Elections:
+   - OfferID:
+     * All: 62c5c138-aad3-10d7-5aa1-b5a4416f60bd
+   - Show if:
+     * usElection2016DiscountSlider flag is true
+     * on '/us-election-2016' stream page
+     * this prompt has not been closed, or was last closed more than 30 days ago
+
+General rules:
+  - Show if:
+    * not logged in
+    * not on a barrier page
+    * b2cMessagePrompt flag is true
+
+This will make the general checks to decide if one of the sliders should
+show and which one. And then allow the prompt logic to further decide.
+*/
 
 const isLoggedIn = utils.getCookie('FTSession');
 
-const getProductSelectorLastSeen = () => {
-	const sessionStore = new Superstore('session', 'next.product-selector');
-	return sessionStore.get('last-seen');
+const isElectionPage = () => {
+	const usElection2016SectionID = 'N2UxNTM3MzItNWNlZC00MDc5LWI3ODUtYWNmZDA2YjE0MWE2-U2VjdGlvbnM=';
+	let conceptId = document.documentElement.getAttribute('data-concept-id') || null;
+	return (conceptId && conceptId === usElection2016SectionID);
 };
+/*
+@param {Object} flags -
+*/
+export default function init (flags) {
+	const messagesEnabled = flags.get('b2cMessagePrompt');
 
-const getPromptLastClosed = () => promptLastSeenStorage.get(promptLastSeenStorageKey);
-
-const setPromptLastClosed = () => promptLastSeenStorage.set(promptLastSeenStorageKey, Date.now());
-
-const getTlsVersion = () => fetch('https://www.howsmyssl.com/a/check')
-	.then(response => response.json())
-	.then(({ tls_version = '' } = { }) => Number.parseFloat(tls_version.replace('TLS ', '')));
-
-/**
- * Show the prompt if
- *	* not logged in
- *	* not on a barrier page
- *	* the barrier has been seen in this session
- *	* the prompt has not been closed, or was last closed more than 30 days ago
- *	* browser's' TLS version is > 1.0
- */
-const shouldPromptBeShown = () => {
-	if (isLoggedIn() || document.querySelector('.ft-subscription-panel')) {
-		return Promise.resolve(false);
-	} else {
-		return Promise.all([getProductSelectorLastSeen(), getPromptLastClosed(), getTlsVersion()])
-			.then(([barrierLastSeen, promptLastClosed, tlsVersion]) =>
-				barrierLastSeen && (!promptLastClosed || promptLastClosed + (1000 * 60 * 60 * 24 * 30) <= Date.now()) && tlsVersion > 1.0
-			);
+	if (isLoggedIn() || document.querySelector('.ft-subscription-panel') || !messagesEnabled) {
+		return;
 	}
-};
-
-const popupTemplate = ({ discount, price, offerId }) => `
-	<article class="subscription-prompt--wrapper" data-trackable="subscription-offer-prompt">
-		<button class="n-sliding-popup-close" data-n-component="n-sliding-popup-close" data-trackable="close">
-			<span class="n-sliding-popup-close-label">Close</span>
-		</button>
-		<div class="subscription-prompt--header" data-o-grid-colspan="12">
-			<span class="subscription-prompt--flag">Limited Offer</span>
-			<h1 class="subscription-prompt--heading">You qualify for a ${discount}% subscription discount</h1>
-			<span class="subscription-prompt--subheading">
-				Pay just ${price} per week for annual Standard Digital access
-			</span>
-		</div>
-		<div class="subscription-prompt--info" data-o-grid-colspan="7">
-			<ul class="subscription-prompt--benefits">
-				<li class="subscription-prompt--benefit">Access FT.com on your desktop, mobile &amp; tablet</li>
-				<li class="subscription-prompt--benefit">5 year company financials archive</li>
-				<li class="subscription-prompt--benefit">Personalised email briefings and market moving news</li>
-			</ul>
-			<a href="https://www.ft.com/signup?offerId=${offerId}" class="subscription-prompt--subscribe-btn" data-trackable="subscribe">Save ${discount}% now</a>
-		</div>
-		<div class="subscription-prompt--aside" data-o-grid-colspan="5">
-			<figure class="subscription-prompt--figure">
-				<img src="https://image.webservices.ft.com/v1/images/raw/${encodeURIComponent('http://next-geebee.ft.com/assets/people/lionel.png')}?source=test&amp;width=126" alt="Lionel Barber, Editor">
-				<figcaption class="subscription-prompt--figure-caption">Lionel Barber, Editor</span>
-			</figure>
-		</div>
-	</article>
-`;
-
-const createPopupHTML = values =>
-	utils.createElement('div', {
-		'class': 'n-sliding-popup subscription-prompt',
-		'data-n-component': 'o-sliding-popup',
-		'data-n-sliding-popup-position': 'bottom left',
-	}, popupTemplate(values));
-
-const createSubscriptionPrompt = values => {
-	const subscriptionPrompt = createPopupHTML(values);
-	subscriptionPrompt.onClose = setPromptLastClosed;
-	document.body.appendChild(subscriptionPrompt);
-	const slidingPopup = new SlidingPopup(subscriptionPrompt);
-	setTimeout(() => {
-		slidingPopup.open();
-		broadcast('oTracking.event', {
-			category: 'message',
-			action: 'show',
-			opportunity: {
-				type: 'discount',
-				subtype: ''
-			},
-			offers: [values.offerId]
-		});
-	}, 2000);
-	return slidingPopup;
-};
-
-const getPrice = countryCode => {
-	const prices = {
-		AUS: [479, 'AUD'],
-		CAN: [470, 'USD'],
-		CHE: [489, 'CHF'],
-		GBR: [399, 'GBP'],
-		HKG: [3690, 'HKD'],
-		JPN: [65300, 'JPN'],
-		SGP: [619, 'SGD'],
-		USA: [429, 'USD'],
-		default: [439, 'EUR']
-	};
-
-	return utils.toCurrency.apply(null, prices[countryCode] || prices.default);
-};
-
-const getSubscriptionPromptValues = countryCode => {
-	const price = getPrice(countryCode);
-	if (countryCode === 'USA') {
-		return { discount: 33, offerId: 'a9582121-87c2-09a7-0cc0-4caf594985d5', price };
-	} else {
-		return { discount: 25, offerId: 'c1773439-53dc-df3d-9acc-20ce2ecde318', price };
+	else {
+		if (isElectionPage()) {
+			return election.init(flags);
+		}
+		else {
+			return lionel.init();
+		}
 	}
-};
-
-export const init = () =>
-	shouldPromptBeShown()
-		.then(shouldShow => {
-			if (shouldShow) {
-				return fetch('/country', { credentials: 'same-origin' })
-					.then(response => response.json())
-					.then((countryCode = 'GBR') => {
-						// NOTE: for now, while pricing is inconsistent across slider, barrier and form, don't show it for these countries
-						if (['SPM', 'ALA', 'BLM', 'MAF', 'AND', 'REU', 'GLP', 'MYT', 'MTQ', 'ZWE'].indexOf(countryCode) > -1) {
-							return;
-						}
-						const subscriptionValues = getSubscriptionPromptValues(countryCode);
-						return createSubscriptionPrompt(subscriptionValues);
-					});
-			}
-		})
-		.catch(error => {
-			broadcast('oErrors.log', {
-				error,
-				info: {
-					message: 'Error initialising subscription offer prompt'
-				}
-			})
-		});
+}

--- a/subscription-offer-prompt/lionel.js
+++ b/subscription-offer-prompt/lionel.js
@@ -1,0 +1,143 @@
+import SlidingPopup from 'n-sliding-popup';
+import Superstore from 'superstore'
+
+import * as utils from './utils';
+import { broadcast } from '../utils';
+
+const promptLastSeenStorage = new Superstore('local', 'n-ui.subscription-offer-prompt');
+const promptLastSeenStorageKey = 'last-closed';
+
+const getProductSelectorLastSeen = () => {
+	const sessionStore = new Superstore('session', 'next.product-selector');
+	return sessionStore.get('last-seen');
+};
+
+const getPromptLastClosed = () => promptLastSeenStorage.get(promptLastSeenStorageKey);
+
+const setPromptLastClosed = () => promptLastSeenStorage.set(promptLastSeenStorageKey, Date.now());
+
+const getTlsVersion = () => fetch('https://www.howsmyssl.com/a/check')
+	.then(response => response.json())
+	.then(({ tls_version = '' } = { }) => Number.parseFloat(tls_version.replace('TLS ', '')));
+
+/**
+ * Show the prompt if
+ *	* not logged in
+ *	* not on a barrier page
+ *	* the barrier has been seen in this session
+ *	* the prompt has not been closed, or was last closed more than 30 days ago
+ *	* browser's' TLS version is > 1.0
+ */
+const shouldPromptBeShown = () => {
+	return Promise.all([getProductSelectorLastSeen(), getPromptLastClosed(), getTlsVersion()])
+			.then(([barrierLastSeen, promptLastClosed, tlsVersion]) =>
+				barrierLastSeen && (!promptLastClosed || promptLastClosed + (1000 * 60 * 60 * 24 * 30) <= Date.now()) && tlsVersion > 1.0
+			);
+};
+
+const popupTemplate = ({ discount, price, offerId }) => `
+	<article class="subscription-prompt--wrapper" data-trackable="subscription-offer-prompt">
+		<button class="n-sliding-popup-close" data-n-component="n-sliding-popup-close" data-trackable="close">
+			<span class="n-sliding-popup-close-label">Close</span>
+		</button>
+		<div class="subscription-prompt--header" data-o-grid-colspan="12">
+			<span class="subscription-prompt--flag">Limited Offer</span>
+			<h1 class="subscription-prompt--heading">You qualify for a ${discount}% subscription discount</h1>
+			<span class="subscription-prompt--subheading">
+				Pay just ${price} per week for annual Standard Digital access
+			</span>
+		</div>
+		<div class="subscription-prompt--info" data-o-grid-colspan="7">
+			<ul class="subscription-prompt--benefits">
+				<li class="subscription-prompt--benefit">Access FT.com on your desktop, mobile &amp; tablet</li>
+				<li class="subscription-prompt--benefit">5 year company financials archive</li>
+				<li class="subscription-prompt--benefit">Personalised email briefings and market moving news</li>
+			</ul>
+			<a href="https://www.ft.com/signup?offerId=${offerId}" class="subscription-prompt--subscribe-btn" data-trackable="subscribe">Save ${discount}% now</a>
+		</div>
+		<div class="subscription-prompt--aside" data-o-grid-colspan="5">
+			<figure class="subscription-prompt--figure">
+				<img src="https://image.webservices.ft.com/v1/images/raw/${encodeURIComponent('http://next-geebee.ft.com/assets/people/lionel.png')}?source=test&amp;width=126" alt="Lionel Barber, Editor">
+				<figcaption class="subscription-prompt--figure-caption">Lionel Barber, Editor</span>
+			</figure>
+		</div>
+	</article>
+`;
+
+const createPopupHTML = values =>
+	utils.createElement('div', {
+		'class': 'n-sliding-popup subscription-prompt',
+		'data-n-component': 'o-sliding-popup',
+		'data-n-sliding-popup-position': 'bottom left',
+	}, popupTemplate(values));
+
+const createSubscriptionPrompt = values => {
+	const subscriptionPrompt = createPopupHTML(values);
+	subscriptionPrompt.onClose = setPromptLastClosed;
+	document.body.appendChild(subscriptionPrompt);
+	const slidingPopup = new SlidingPopup(subscriptionPrompt);
+	setTimeout(() => {
+		slidingPopup.open();
+		broadcast('oTracking.event', {
+			category: 'message',
+			action: 'show',
+			opportunity: {
+				type: 'discount',
+				subtype: ''
+			},
+			offers: [values.offerId]
+		});
+	}, 2000);
+	return slidingPopup;
+};
+
+const getPrice = countryCode => {
+	const prices = {
+		AUS: [479, 'AUD'],
+		CAN: [470, 'USD'],
+		CHE: [489, 'CHF'],
+		GBR: [399, 'GBP'],
+		HKG: [3690, 'HKD'],
+		JPN: [65300, 'JPN'],
+		SGP: [619, 'SGD'],
+		USA: [429, 'USD'],
+		default: [439, 'EUR']
+	};
+
+	return utils.toCurrency.apply(null, prices[countryCode] || prices.default);
+};
+
+const getSubscriptionPromptValues = countryCode => {
+	const price = getPrice(countryCode);
+	if (countryCode === 'USA') {
+		return { discount: 33, offerId: 'a9582121-87c2-09a7-0cc0-4caf594985d5', price };
+	} else {
+		return { discount: 25, offerId: 'c1773439-53dc-df3d-9acc-20ce2ecde318', price };
+	}
+};
+
+export const init = () => {
+	return shouldPromptBeShown()
+		.then(shouldShow => {
+			if (shouldShow) {
+				return fetch('/country', { credentials: 'same-origin' })
+					.then(response => response.json())
+					.then((countryCode = 'GBR') => {
+						// NOTE: for now, while pricing is inconsistent across slider, barrier and form, don't show it for these countries
+						if (['SPM', 'ALA', 'BLM', 'MAF', 'AND', 'REU', 'GLP', 'MYT', 'MTQ', 'ZWE'].indexOf(countryCode) > -1) {
+							return;
+						}
+						const subscriptionValues = getSubscriptionPromptValues(countryCode);
+						return createSubscriptionPrompt(subscriptionValues);
+					});
+			}
+		})
+		.catch(error => {
+			broadcast('oErrors.log', {
+				error,
+				info: {
+					message: 'Error initialising subscription offer prompt'
+				}
+			})
+		});
+}

--- a/subscription-offer-prompt/test/index.spec.js
+++ b/subscription-offer-prompt/test/index.spec.js
@@ -1,114 +1,68 @@
-/* globals should, sinon */
-import SlidingPopup from 'n-sliding-popup';
-import Superstore from 'superstore';
-import { init } from '../index';
+/* globals sinon */
+import subscriptionOfferPrompt from '../index';
+import * as lionel from '../lionel';
+import * as election from '../us-elections';
 
-const delay = (ms, value) => new Promise(resolve => setTimeout(resolve.bind(null, value), ms));
+describe('Subscription Offer Prompt Init', () => {
 
-describe('Subscription Offer Prompt', () => {
-
-	const localStorage = new Superstore('local', 'n-ui.subscription-offer-prompt')
-	const sessionStorage = new Superstore('session', 'next.product-selector')
+	let lionelStub;
+	let electionStub;
+	let flags;
 
 	beforeEach(() => {
 		Object.defineProperty(document, 'cookie', { value: '', configurable: true });
-		const fetchStub = sinon.stub(window, 'fetch');
-		fetchStub
-			.withArgs('/country')
-			.returns(Promise.resolve({
-				json: () => Promise.resolve('GBR')
-			}));
-		fetchStub
-			.withArgs('https://www.howsmyssl.com/a/check')
-			.returns(Promise.resolve({
-				json: () => Promise.resolve({ tls_version: 'TLS 1.2' })
-			}));
-
-		return Promise.all([
-			localStorage.set('last-closed', Date.now() - (1000 * 60 * 60 * 24 * 30)),
-			sessionStorage.set('last-seen', Date.now())
-		])
+		lionelStub = sinon.spy(lionel, 'init');
+		electionStub = sinon.spy(election, 'init');
+		// stub out the flag.get()
+		flags = { get: () => true }
 	});
 
 	afterEach(() => {
-		window.fetch.restore();
 		delete document.cookie;
-
-		return Promise.all([
-			localStorage.unset('last-closed'),
-			sessionStorage.unset('last-seen')
-		]);
+		lionelStub.restore();
+		electionStub.restore();
+		flags = null;
 	});
 
-	it('should show prompt if navigated from barrier page, not on a barrier page, not logged in and hasnt been shown in 30 days', () =>
-		init().then(popup => popup.should.be.an instanceof(SlidingPopup))
-	);
-
-	it('should have correct attributes', () =>
-		init().then(popup => {
-			popup.el.getAttribute('class').should.include('n-sliding-popup subscription-prompt');
-			popup.el.getAttribute('data-n-component').should.equal('o-sliding-popup');
-			popup.el.getAttribute('data-n-sliding-popup-position').should.equal('bottom left');
-		})
-	);
-
-	it('should have correct html', () =>
-		init().then(popup => {
-			popup.el.innerHTML.should.contain('You qualify for a 25% subscription discount')
-		})
-	);
-
-	it('should set onClose to function', () =>
-		init().then(popup => {
-			popup.el.onClose.should.be.a('function')
-		})
-	);
-
-	it('should store date in local storage when closed', () =>
-		init()
-			.then(popup => {
-				popup.el.onClose();
-				return localStorage.get('last-closed');
-			})
-			// give a 1s buffer
-			.then(lastClosed => lastClosed.should.be.closeTo(Date.now(), 1000))
-	);
-
-	// TODO: naughty, but errors for unknown reason - https://circleci.com/gh/Financial-Times/n-ui/2829
-	xit('should ‘pop-up’ after 2 seconds', () =>
-		init()
-			.then(popup => {
-				sinon.spy(popup, 'open');
-				popup.open.should.not.have.been.called;
-				return delay(2050, popup);
-			})
-			.then(popup => popup.open.should.have.callCount(1))
-	);
-
-	it('should not not show on barrier pages', () => {
+	it('should not init either prompt if on barrier pages', () => {
 		const barrier = document.createElement('div');
 		barrier.className = 'ft-subscription-panel';
 		document.body.appendChild(barrier);
-		return init()
-			.then(popup => {
-				document.body.removeChild(barrier);
-				should.not.exist(popup);
-			});
+
+		subscriptionOfferPrompt(flags);
+		lionelStub.should.not.have.been.called;
+		electionStub.should.not.have.been.called;
+
+		document.body.removeChild(barrier);
 	});
 
-	it('should not show if logged in', () => {
+	it('should not init either prompt if logged in', () => {
 		Object.defineProperty(document, 'cookie', { value: 'FTSession=foo', configurable: true });
-		return init().then(popup => should.not.exist(popup));
+
+		subscriptionOfferPrompt(flags);
+		lionelStub.should.not.have.been.called;
+		electionStub.should.not.have.been.called;
 	});
 
-	it('should not show if last shown within 30 days', () => {
-		localStorage.set('last-closed', Date.now() + (1000 * 60 * 60 * 24 * 29));
-		return init().then(popup => should.not.exist(popup));
+	it('should not init either prompt if b2cMessagePrompt flag is false', () => {
+		flags.get = () => false;
+
+		subscriptionOfferPrompt(flags);
+		lionelStub.should.not.have.been.called;
+		electionStub.should.not.have.been.called;
 	});
 
-	it('should not show barrier page has not been visited in this session', () => {
-		sessionStorage.unset('last-seen');
-		return init().then(popup => should.not.exist(popup));
+	it('should init "Lionel slider" if NOT logged in & NOT on barrier page & NOT on /us-election-2016 page', () => {
+		subscriptionOfferPrompt(flags);
+		lionelStub.should.have.callCount(1);
+		electionStub.should.have.not.been.called;
+	});
+
+	it('should init "2016 US Election slider" if NOT logged in & on /us-election-2016 stream page', () => {
+		document.documentElement.setAttribute('data-concept-id', 'N2UxNTM3MzItNWNlZC00MDc5LWI3ODUtYWNmZDA2YjE0MWE2-U2VjdGlvbnM=')
+		subscriptionOfferPrompt(flags);
+		electionStub.should.have.callCount(1);
+		document.documentElement.removeAttribute('data-concept-id');
 	});
 
 });

--- a/subscription-offer-prompt/test/lionel.spec.js
+++ b/subscription-offer-prompt/test/lionel.spec.js
@@ -1,0 +1,97 @@
+/* globals should, sinon */
+import SlidingPopup from 'n-sliding-popup';
+import Superstore from 'superstore';
+import { init } from '../lionel';
+
+const delay = (ms, value) => new Promise(resolve => setTimeout(resolve.bind(null, value), ms));
+
+describe('"Lionel Slider" Subscription Offer Prompt', () => {
+
+	const localStorage = new Superstore('local', 'n-ui.subscription-offer-prompt')
+	const sessionStorage = new Superstore('session', 'next.product-selector')
+
+	beforeEach(() => {
+		const fetchStub = sinon.stub(window, 'fetch');
+		fetchStub
+			.withArgs('/country')
+			.returns(Promise.resolve({
+				json: () => Promise.resolve('GBR')
+			}));
+		fetchStub
+			.withArgs('https://www.howsmyssl.com/a/check')
+			.returns(Promise.resolve({
+				json: () => Promise.resolve({ tls_version: 'TLS 1.2' })
+			}));
+
+		return Promise.all([
+			localStorage.set('last-closed', Date.now() - (1000 * 60 * 60 * 24 * 30)),
+			sessionStorage.set('last-seen', Date.now())
+		])
+	});
+
+	afterEach(() => {
+		window.fetch.restore();
+
+		return Promise.all([
+			localStorage.unset('last-closed'),
+			sessionStorage.unset('last-seen')
+		]);
+	});
+
+	it('should show prompt if navigated from barrier page, not on a barrier page and hasnt been shown in 30 days', () =>
+		init().then(popup => popup.should.be.an.instanceof(SlidingPopup))
+	);
+
+	it('should have correct attributes', () =>
+		init().then(popup => {
+			popup.el.getAttribute('class').should.include('n-sliding-popup subscription-prompt');
+			popup.el.getAttribute('data-n-component').should.equal('o-sliding-popup');
+			popup.el.getAttribute('data-n-sliding-popup-position').should.equal('bottom left');
+		})
+	);
+
+	it('should have correct html', () =>
+		init().then(popup => {
+			popup.el.innerHTML.should.contain('You qualify for a 25% subscription discount')
+		})
+	);
+
+	it('should set onClose to function', () =>
+		init().then(popup => {
+			popup.el.onClose.should.be.a('function')
+		})
+	);
+
+	it('should store date in local storage when closed', () =>
+		init()
+			.then(popup => {
+				popup.el.onClose();
+				return localStorage.get('last-closed');
+			})
+			// give a 1s buffer
+			.then(lastClosed => lastClosed.should.be.closeTo(Date.now(), 1000))
+	);
+
+	// TODO: naughty, but errors for unknown reason - https://circleci.com/gh/Financial-Times/n-ui/2829
+	xit('should ‘pop-up’ after 2 seconds', () =>
+		init()
+			.then(popup => {
+				sinon.spy(popup, 'open');
+				popup.open.should.not.have.been.called;
+				return delay(2050, popup);
+			})
+			.then(popup => popup.open.should.have.callCount(1))
+	);
+
+
+	it('should not show if last shown within 30 days', () => {
+		localStorage.set('last-closed', Date.now() + (1000 * 60 * 60 * 24 * 29));
+		return init().then(popup => should.not.exist(popup));
+	});
+
+	it('should not show barrier page has not been visited in this session', () => {
+		sessionStorage.unset('last-seen');
+		return init().then(popup => should.not.exist(popup));
+	});
+
+});

--- a/subscription-offer-prompt/test/us-elections.spec.js
+++ b/subscription-offer-prompt/test/us-elections.spec.js
@@ -1,0 +1,101 @@
+/* globals should, sinon */
+import SlidingPopup from 'n-sliding-popup';
+import Superstore from 'superstore';
+import { init } from '../us-elections';
+
+const delay = (ms, value) => new Promise(resolve => setTimeout(resolve.bind(null, value), ms));
+
+describe('"US Election 2016" Subscription Offer Prompt', () => {
+
+	const localStorage = new Superstore('local', 'n-ui.subscription-offer-prompt-us-elections')
+	let flags;
+
+	beforeEach(() => {
+		const fetchStub = sinon.stub(window, 'fetch');
+		fetchStub
+			.withArgs('/country')
+			.returns(Promise.resolve({
+				json: () => Promise.resolve('GBR')
+			}));
+		fetchStub
+			.withArgs('https://next-signup-api.ft.com/offer/62c5c138-aad3-10d7-5aa1-b5a4416f60bd?countryCode=GBR')
+			.returns(Promise.resolve({
+				json: () => Promise.resolve({
+					data: {offer:{id:'62c5c138-aad3-10d7-5aa1-b5a4416f60bd',charges:[{billing_period:'trial',duration_code:'P3M',amount:{symbol:'£',currency:'GBP',value:'50.00'}},{billing_period:'monthly',duration_code:'P1M',amount:{symbol:'£',currency:'GBP',value:'44.00'}}]}}})
+			}));
+
+		// stub out the flag.get()
+		flags = { get: () => true }
+
+		return localStorage.set('last-closed', Date.now() - (1000 * 60 * 60 * 24 * 30));
+	});
+
+	afterEach(() => {
+		window.fetch.restore();
+		flags = null;
+
+		return Promise.all([
+			localStorage.unset('last-closed')
+		]);
+	});
+
+	it('should show prompt if not on a barrier page and hasnt been shown in 30 days', () =>
+		init(flags).then(popup => popup.should.be.an.instanceof(SlidingPopup))
+	);
+
+	it('should have correct attributes', () =>
+		init(flags).then(popup => {
+			popup.el.getAttribute('class').should.include('n-sliding-popup subscription-prompt');
+			popup.el.getAttribute('data-n-component').should.equal('o-sliding-popup');
+			popup.el.getAttribute('data-n-sliding-popup-position').should.equal('bottom left');
+		})
+	);
+
+	it('should have correct html', () =>
+		init(flags).then(popup => {
+			popup.el.innerHTML.should.contain('Your global perspective this US election')
+			popup.el.innerHTML.should.contain('GBP')
+			popup.el.innerHTML.should.contain('£')
+			popup.el.innerHTML.should.contain('50.00')
+		})
+	);
+
+	it('should set onClose to function', () =>
+		init(flags).then(popup => {
+			popup.el.onClose.should.be.a('function')
+		})
+	);
+
+	it('should store date in local storage when closed', () =>
+		init(flags)
+			.then(popup => {
+				popup.el.onClose();
+				return localStorage.get('last-closed');
+			})
+			// give a 1s buffer
+			.then(lastClosed => lastClosed.should.be.closeTo(Date.now(), 1000))
+	);
+
+	// TODO: naughty, but errors for unknown reason - https://circleci.com/gh/Financial-Times/n-ui/2829
+	xit('should ‘pop-up’ after 2 seconds', () =>
+		init(flags)
+			.then(popup => {
+				sinon.spy(popup, 'open');
+				popup.open.should.not.have.been.called;
+				return delay(2050, popup);
+			})
+			.then(popup => popup.open.should.have.callCount(1))
+	);
+
+
+	it('should not show if last shown within 30 days', () => {
+		localStorage.set('last-closed', Date.now() + (1000 * 60 * 60 * 24 * 29));
+		return init(flags).then(popup => should.not.exist(popup));
+	});
+
+	it('should not show if flag usElection2016DiscountSlider is false', () => {
+		flags.get = () => false;
+		return init(flags).then(popup => should.not.exist(popup));
+	});
+
+});

--- a/subscription-offer-prompt/us-elections.js
+++ b/subscription-offer-prompt/us-elections.js
@@ -1,0 +1,107 @@
+import SlidingPopup from 'n-sliding-popup';
+import Superstore from 'superstore'
+
+import * as utils from './utils';
+import { broadcast } from '../utils';
+
+const promptLastSeenStorage = new Superstore('local', 'n-ui.subscription-offer-prompt-us-elections');
+const promptLastSeenStorageKey = 'last-closed';
+
+const getPromptLastClosed = () => promptLastSeenStorage.get(promptLastSeenStorageKey);
+
+const setPromptLastClosed = () => promptLastSeenStorage.set(promptLastSeenStorageKey, Date.now());
+
+/**
+ * Show the prompt if
+ *	* the prompt has not been closed, or was last closed more than 30 days ago
+ *	* usElection2016DiscountSlider flag is true
+ */
+const shouldPromptBeShown = (flags) => {
+	return getPromptLastClosed()
+			.then(promptLastClosed => {
+				return (!promptLastClosed || promptLastClosed + (1000 * 60 * 60 * 24 * 30) <= Date.now()) && flags.get('usElection2016DiscountSlider');
+			})
+};
+
+const popupTemplate = ({ amount }) => `
+	<article class="subscription-prompt--wrapper" data-trackable="subscription-offer-prompt-us-elections">
+		<button class="n-sliding-popup-close" data-n-component="n-sliding-popup-close" data-trackable="close">
+			<span class="n-sliding-popup-close-label">Close</span>
+		</button>
+		<div class="subscription-prompt--header" data-o-grid-colspan="12">
+			<span class="subscription-prompt--flag">Limited Offer</span>
+			<h1 class="subscription-prompt--heading">Your global perspective this US election</h1>
+			<span class="subscription-prompt--subheading">
+				Get the latest news and analysis in the race for the White House.
+			</span>
+		</div>
+		<a href="https://sub.ft.com/spa_uselection/?segmentId=b0cc72ef-a788-b64a-8860-bbd7e9713d62&utm_source=election&utm_medium=onsite_link&utm_campaign=2016_Q4_US_Election_poll_page" data-trackable="subscribe">Try the FT for 3 months for <small>${amount.currency}</small>${amount.symbol}${amount.value}</a>
+	</article>
+`;
+
+const createPopupHTML = values =>
+	utils.createElement('div', {
+		'class': 'n-sliding-popup subscription-prompt',
+		'data-n-component': 'o-sliding-popup',
+		'data-n-sliding-popup-position': 'bottom left',
+	}, popupTemplate(values));
+
+const createSubscriptionPrompt = values => {
+	const subscriptionPrompt = createPopupHTML(values);
+	subscriptionPrompt.onClose = setPromptLastClosed;
+	document.body.appendChild(subscriptionPrompt);
+	const slidingPopup = new SlidingPopup(subscriptionPrompt);
+	setTimeout(() => {
+		slidingPopup.open();
+		broadcast('oTracking.event', {
+			category: 'message',
+			action: 'show',
+			opportunity: {
+				type: 'discount',
+				subtype: ''
+			},
+			offers: [values.offerId]
+		});
+	}, 2000);
+	return slidingPopup;
+};
+
+const fetchOffer = (countryCode) => {
+	const url = `https://next-signup-api.ft.com/offer/62c5c138-aad3-10d7-5aa1-b5a4416f60bd?countryCode=${countryCode}`;
+
+	return fetch(url,
+		{
+			credentials: 'same-origin',
+			'x-api-env': 'prod'
+		})
+		.then(response => response.json())
+		.then(({ data }={}) => {
+			const pricing = data.offer.charges.find(p => p.billing_period === 'trial');
+			return {offerId: data.offer.id, amount: pricing.amount}
+		})
+}
+
+export const init = (flags) => {
+	return shouldPromptBeShown(flags)
+		.then(shouldShow => {
+			if (shouldShow) {
+				return fetch('/country', { credentials: 'same-origin' })
+					.then(response => response.json())
+					.then((countryCode = 'GBR') => {
+						return fetchOffer(countryCode)
+					})
+					.then(pricing => {
+						const subscriptionValues = pricing;
+						return createSubscriptionPrompt(subscriptionValues);
+					});
+			}
+		})
+		.catch(error => {
+			broadcast('oErrors.log', {
+				error,
+				info: {
+					message: 'Error initialising subscription offer prompt'
+				}
+			})
+		});
+}


### PR DESCRIPTION
This looks bigger than it is: 
*index.spec.js* -> *lionel.spec.js*
*index.js* -> *lionel.js*

---

First pass at US elections prompt for testing, css work left.

- Change how the subscription offer prompt is inited so that we
can pass in flags.
- Moved some generic logic about if and which offer to show into
index.
- Split Lionel slider and US election slider into seperate files
- refactor tests
  - add tests for index, lionel and new US offer