### PR TITLE
Remove showExpectedCount from push notifications

### DIFF
--- a/myft/js/push-notifications.js
+++ b/myft/js/push-notifications.js
@@ -34,28 +34,6 @@ function init () {
 	}
 }
 
-function showExpectedCount () {
-	myftClient.personaliseUrl('/myft/average-push-frequency/').then(function (url) {
-		fetch(url, {
-			headers: {
-				'Content-Type': 'application/json',
-				'Accept': 'application/json'
-			},
-			credentials: 'include'
-		})
-		.then(res => res.json())
-		.then(function (data) {
-			// TODO: Remove the label[0] selector after launching the new prefs page
-			const el = infoText || pushButtonContainer.getElementsByTagName('label')[0];
-
-			if(data && data.pushesPerDay && el) {
-				el.textContent += ` (~${data.pushesPerDay} alerts a day)`;
-			}
-		});
-	});
-
-}
-
 // Once the service worker is registered set the initial state
 function initialiseState () {
 	// Are Notifications supported in the service worker?
@@ -92,7 +70,6 @@ function initialiseState () {
 				// push messages.
 				pushButton.disabled = false;
 				pushButtonContainer.classList.add('js-push-supported');
-				showExpectedCount();
 				if (!subscription) {
 					// We aren't subscribed to push, so set UI
 					// to allow the user to enable push


### PR DESCRIPTION
Remove _n alerts a day_ bit from push notifications because this is the only use of `/myft/average-push-frequency/` and we'd like to remove that from myFT page as it's backed up by personalised-feed (which we're trying to kill).

Note that push notifications are currently out of use, so this will not be a customer facing change.