### PR TITLE
proxy demo api calls to ft.com

### DIFF
--- a/_test-server/app.js
+++ b/_test-server/app.js
@@ -36,6 +36,13 @@ app.get('/', (req, res) => {
 	});
 });
 
+app.get('*', (req, res) => {
+	fetch('https://www.ft.com' + req.originalUrl)
+		.then(response => {
+			response.body.pipe(res);
+		})
+});
+
 app.listen(5005)
 	.then(app => {
 		// in CI generate a test page and send it to S3


### PR DESCRIPTION
This means that api calls will work in the demo app, so e.g. typeahead works (verified), myft works (in theory)

cc @lc512k @GlynnPhillips Useful for pally?