### PR TITLE
Use data-trackable string as tracking id

### DIFF
--- a/tracking/ft/events/scroll-depth-components.js
+++ b/tracking/ft/events/scroll-depth-components.js
@@ -6,11 +6,11 @@ const track = (componentId, componentPos) =>
 const intersectionCallback = (observer, changes) =>
 	changes.forEach(change => {
 		const component = change.target;
-		const componentTrackable = component.getAttribute('data-trackable');
+		const componentId = component.id || component.getAttribute('data-trackable');
 		// get the component's position
 		const componentPos = [...document.querySelectorAll('.js-track-scroll-event')]
-			.findIndex(component => component.getAttribute('data-trackable') === componentTrackable);
-		track(componentTrackable, componentPos + 1);
+			.findIndex(component => (component.id || component.getAttribute('data-trackable')) === componentId);
+		track(componentId, componentPos + 1);
 		observer.unobserve(component);
 	});
 

--- a/tracking/ft/events/scroll-depth-components.js
+++ b/tracking/ft/events/scroll-depth-components.js
@@ -6,11 +6,11 @@ const track = (componentId, componentPos) =>
 const intersectionCallback = (observer, changes) =>
 	changes.forEach(change => {
 		const component = change.target;
-		const componentId = component.id;
+		const componentTrackable = component.getAttribute('data-trackable');
 		// get the component's position
 		const componentPos = [...document.querySelectorAll('.js-track-scroll-event')]
-			.findIndex(component => component.id === componentId);
-		track(componentId, componentPos + 1);
+			.findIndex(component => component.getAttribute('data-trackable') === componentTrackable);
+		track(componentTrackable, componentPos + 1);
 		observer.unobserve(component);
 	});
 


### PR DESCRIPTION
When browsing the codebase, it’s not clear that HTML `id`s are being used for more than just n-section (which is in the process of being removed). A few of us have been gradually stripping out these `id`s on that basis. It seems likely that this mistake will be made again, hence this PR.

Most `id`s across the site have the same value as their respective `data-trackable` strings, and any discrepancies will be resolved shortly.

@adgad