### PR TITLE
open survey in a new window

### DIFF
--- a/header/template.html
+++ b/header/template.html
@@ -1,4 +1,4 @@
-<a data-trackable="a11y-survey-screen-reader" class="n-util-visually-hidden" href="https://www.surveymonkey.co.uk/r/8HGPJHD">Accessibility survey: Please help us improve accessibility on FT.com</a>
+<a data-trackable="a11y-survey-screen-reader" class="n-util-visually-hidden" target="_blank" href="https://www.surveymonkey.co.uk/r/8HGPJHD">Accessibility survey: Please help us improve accessibility on FT.com</a>
 <a data-trackable="a11y-skip-to-navigation" class="n-util-visually-hidden" href="#primary-nav">Skip to navigation</a>
 <a data-trackable="a11y-skip-to-content" class="n-util-visually-hidden" href="#site-content">Skip to content</a>
 

--- a/welcome-message/banner.html
+++ b/welcome-message/banner.html
@@ -7,7 +7,7 @@
 				<a href="/tour" class="n-welcome-banner__button" data-trackable="tour-page" data-component="cta-take-tour"><span class="n-welcome-banner__cta--s">View </span>tips</a>
 			</p>
 			<div class="n-welcome-banner__column n-welcome-banner__column--actions">
-				<a class="n-welcome-banner__link-action" href="https://www.surveymonkey.co.uk/r/8HGPJHD">Take the accessibility survey</a>
+				<a class="n-welcome-banner__link-action" target="_blank" href="https://www.surveymonkey.co.uk/r/8HGPJHD">Take the accessibility survey</a>
 			</div>
 		</div>
 		{{!-- button must be present in the HTML as a requirement/limitation of o-expander --}}
@@ -23,12 +23,12 @@
 				<a href="/tour" class="n-welcome-banner__button" data-trackable="tour-page" data-component="cta-take-tour"><span class="n-welcome-banner__cta--s">View </span>Tips</a>
 			</p>
 			<div class="n-welcome-banner__column n-welcome-banner__column--actions">
-				<a class="n-welcome-banner__link-action" href="https://www.surveymonkey.co.uk/r/8HGPJHD">Take the accessibility survey</a>
+				<a class="n-welcome-banner__link-action" target="_blank" href="https://www.surveymonkey.co.uk/r/8HGPJHD">Take the accessibility survey</a>
 			</div>
 		</div>
 		{{!-- button must be present in the HTML as a requirement/limitation of o-expander --}}
 		<div class="n-welcome-banner__column">
-			<button data-trackable="toggled"  title="Close welcome banner" class="n-welcome-banner__button--toggler o-if-js if-fixed"></button>
+			<button data-trackable="toggled" title="Close welcome banner" class="n-welcome-banner__button--toggler o-if-js if-fixed"></button>
 		</div>
 	{{/if}}
 </div>

--- a/welcome-message/banner.html
+++ b/welcome-message/banner.html
@@ -7,7 +7,7 @@
 				<a href="/tour" class="n-welcome-banner__button" data-trackable="tour-page" data-component="cta-take-tour"><span class="n-welcome-banner__cta--s">View </span>tips</a>
 			</p>
 			<div class="n-welcome-banner__column n-welcome-banner__column--actions">
-				<a class="n-welcome-banner__link-action" target="_blank" href="https://www.surveymonkey.co.uk/r/8HGPJHD">Take the accessibility survey</a>
+				<a class="n-welcome-banner__link-action" target="_blank" data-trackable="" href="https://www.surveymonkey.co.uk/r/8HGPJHD">Take the accessibility survey</a>
 			</div>
 		</div>
 		{{!-- button must be present in the HTML as a requirement/limitation of o-expander --}}
@@ -23,7 +23,7 @@
 				<a href="/tour" class="n-welcome-banner__button" data-trackable="tour-page" data-component="cta-take-tour"><span class="n-welcome-banner__cta--s">View </span>Tips</a>
 			</p>
 			<div class="n-welcome-banner__column n-welcome-banner__column--actions">
-				<a class="n-welcome-banner__link-action" target="_blank" href="https://www.surveymonkey.co.uk/r/8HGPJHD">Take the accessibility survey</a>
+				<a class="n-welcome-banner__link-action" target="_blank" data-trackable="" href="https://www.surveymonkey.co.uk/r/8HGPJHD">Take the accessibility survey</a>
 			</div>
 		</div>
 		{{!-- button must be present in the HTML as a requirement/limitation of o-expander --}}

--- a/welcome-message/banner.html
+++ b/welcome-message/banner.html
@@ -7,7 +7,7 @@
 				<a href="/tour" class="n-welcome-banner__button" data-trackable="tour-page" data-component="cta-take-tour"><span class="n-welcome-banner__cta--s">View </span>tips</a>
 			</p>
 			<div class="n-welcome-banner__column n-welcome-banner__column--actions">
-				<a class="n-welcome-banner__link-action" target="_blank" data-trackable="" href="https://www.surveymonkey.co.uk/r/8HGPJHD">Take the accessibility survey</a>
+				<a class="n-welcome-banner__link-action" data-trackable="a11y-survey-banner" target="_blank" data-trackable="" href="https://www.surveymonkey.co.uk/r/8HGPJHD">Take the accessibility survey</a>
 			</div>
 		</div>
 		{{!-- button must be present in the HTML as a requirement/limitation of o-expander --}}
@@ -23,7 +23,7 @@
 				<a href="/tour" class="n-welcome-banner__button" data-trackable="tour-page" data-component="cta-take-tour"><span class="n-welcome-banner__cta--s">View </span>Tips</a>
 			</p>
 			<div class="n-welcome-banner__column n-welcome-banner__column--actions">
-				<a class="n-welcome-banner__link-action" target="_blank" data-trackable="" href="https://www.surveymonkey.co.uk/r/8HGPJHD">Take the accessibility survey</a>
+				<a class="n-welcome-banner__link-action" data-trackable="a11y-survey-banner" target="_blank" data-trackable="" href="https://www.surveymonkey.co.uk/r/8HGPJHD">Take the accessibility survey</a>
 			</div>
 		</div>
 		{{!-- button must be present in the HTML as a requirement/limitation of o-expander --}}


### PR DESCRIPTION
@i-like-robots Survey Monkey currently leaves the user in a blank page when they finish the survey :|

Ideally, they'd redirect them to the page they came from (could be any inside ft.com) but we've been told it's not possible. 

We've opted for opening the survey in a new window and then having survey monkey close itself when finished. Not ideal, but perhaps less disorienting than opening in the same window then offering a link back to ft.com when done (rather than the article they actually came from, for example)?