### PR TITLE
Hide the banner promo for anon users

### DIFF
--- a/.pa11yci.js
+++ b/.pa11yci.js
@@ -53,6 +53,7 @@ const pa11yIgnore = [
 	'test',
 	'tour-tip',
 	'tour-tip-group',
+	'tooltip',
 	'tracking',
 	'typography',
 	'utils',

--- a/header/js/promoHandler.js
+++ b/header/js/promoHandler.js
@@ -93,7 +93,7 @@ function sessionIsForWeekendUser (session) {
 }
 
 function showElectionsOffer (flags) {
-	return flags.get('discountOn');
+	return flags.get('discountOn') && flags.get('headerMarketingPromo');
 }
 
 /**

--- a/header/js/promoHandler.js
+++ b/header/js/promoHandler.js
@@ -32,7 +32,9 @@ function supportsCors () {
 function decorateTheSession (session) {
 	session.isForRegisteredUser = sessionIsForRegisteredUser(session);
 	session.isForWeekendUser = sessionIsForWeekendUser(session);
-	session.isForAnonymousUser = !session.products;
+	// TODO: Fix required. Some user sessions are falsely returning
+	// no products. see https://jira.ft.com/browse/NFT-700
+	// session.isForAnonymousUser = !session.products;
 	return session;
 }
 
@@ -115,7 +117,9 @@ export function init (flags) {
 				.then(extractResult)
 				.then(decorateTheSession)
 				.then(function (session) {
-					if (session.isForAnonymousUser || session.isForRegisteredUser || session.isForWeekendUser) {
+					if (//session.isForAnonymousUser || // TODO: see decorateTheSession()
+						session.isForRegisteredUser ||
+						session.isForWeekendUser) {
 
 						if (showElectionsOffer(flags)) {
 							showElectionPromo()


### PR DESCRIPTION
Due to a bug in how the next-session api is reporting a users
products we are falesly showing the banner to SUB'd users.

This removes the logic that sets the isAnonUser flag until fixed.