### PR TITLE
Fix the focus outline of breadcrumb when navigating via keyboard

### DIFF
--- a/header/main.scss
+++ b/header/main.scss
@@ -14,6 +14,14 @@
 			display: block;
 		}
 
+		// inelegant gymnastics to fix focus outline of the first breadcrumb link
+		.o-header__subnav-wrap-outside {
+			margin-left: -2px;
+		}
+		.o-header__subnav-list--breadcrumb .o-header__subnav-item:first-child .o-header__subnav-link {
+			margin-left: 2px;
+		}
+
 		// add next opt-out buttons
 		.o-header__drawer-menu-button {
 			@include oButtons('medium', 'standout');


### PR DESCRIPTION
Fixes issue DAC-USER-KO-T10-03 of the accessibility report.

@lc512k @GlynnPhillips 

Before:
![subnav-before](https://cloud.githubusercontent.com/assets/150157/21158116/d829b15c-c173-11e6-8984-0a1bd00189c7.gif)

After:
![subnav-after](https://cloud.githubusercontent.com/assets/150157/21158123/dc2059fa-c173-11e6-8a03-70402baf7973.gif)
