### PR TITLE
Amend: Welcome banner hover state color

### DIFF
--- a/welcome-message/main.scss
+++ b/welcome-message/main.scss
@@ -177,7 +177,8 @@
 		margin: 0 0 0 $spacing-unit/2;
 		color: getColor('white');
 		border-bottom-color: getColor('white');
-		&:hover {
+		&:hover,
+		&:focus {
 			color: getColor('white');
 		}
 	}


### PR DESCRIPTION
cc @lc512k 

Addresses mention of welcome banner in: https://github.com/Financial-Times/next-a11y/issues/18

### Non-hover state
![non-hover](https://cloud.githubusercontent.com/assets/10484515/21310482/7986aa86-c5da-11e6-9ea3-3fb9c9515181.png)

### Hover state (before)
![hover-before](https://cloud.githubusercontent.com/assets/10484515/21310484/79880430-c5da-11e6-8f2b-51612fc6e17e.png)

### Hover state (after)
![hover-after](https://cloud.githubusercontent.com/assets/10484515/21310483/7986ec58-c5da-11e6-99f9-573db34ad1a2.png)