### PR TITLE
Update .n-util-visually-hidden

### DIFF
--- a/utils/main.scss
+++ b/utils/main.scss
@@ -34,12 +34,12 @@
 
 	.n-util-visually-hidden {
 		position: absolute;
-		clip: rect(0 0 0 0);
 		margin: -1px;
 		border: 0;
 		overflow: hidden;
 		padding: 0;
-		width: 1px;
+		width: 0;
+		height: 0;
 		white-space: nowrap;
 	}
 

--- a/utils/main.scss
+++ b/utils/main.scss
@@ -40,7 +40,6 @@
 		overflow: hidden;
 		padding: 0;
 		width: 1px;
-		height: 1px;
 		white-space: nowrap;
 	}
 


### PR DESCRIPTION
Having `n-util-visually-hidden` with `height: 1px` causes screen readers to read out the hidden box before anything else in its parent in Chrome, which is not always what we want (see `Digital Accessibility Centre (DAC)` link in https://www.ft.com/accessibility using Voice Over).

Can you think of any issues removing `height: 1px` would cause visually @GlynnPhillips @i-like-robots ? 