### PR TITLE
Adding ticks for downloadable articles

### DIFF
--- a/.pa11yci.js
+++ b/.pa11yci.js
@@ -20,6 +20,7 @@ const config = {
 
 const pa11yIgnore = [
 	'.git',
+	'.idea',
 	'node_modules',
 	'bower_components',
 	'public',
@@ -61,7 +62,8 @@ const pa11yIgnore = [
 	'typography',
 	'utils',
 	'viewport',
-	'welcome-message'
+	'welcome-message',
+	'syndication'
 ];
 
 function getDirectories(srcpath) {

--- a/bootstrap.scss
+++ b/bootstrap.scss
@@ -22,6 +22,7 @@
 @import 'page-heading/main';
 @import 'tooltip/main';
 @import 'offline-toast/main';
+@import 'syndication/main';
 
 // TODO: move these components into n-ui
 @import 'cookie-message/main';

--- a/configure.scss
+++ b/configure.scss
@@ -30,7 +30,8 @@ $n-ui-features: (
 	typography: 'critical',
 	utils: 'critical',
 	welcomeMessage: true,
-	tooltip: true
+	tooltip: true,
+	syndication: false
 ) !default;
 
 /// Declare any feature dependencies
@@ -52,7 +53,8 @@ $n-ui-presets: (
 		myftHint: 'critical',
 		notification: true,
 		welcomeMessage: true,
-		tooltip: true
+		tooltip: true,
+		syndication: true
 	)
 );
 

--- a/js-setup/js/component-initializer.js
+++ b/js-setup/js/component-initializer.js
@@ -14,6 +14,7 @@ import myftHint from '../../myft-hint';
 import offlineToast from '../../offline-toast';
 import { lazyLoad as lazyLoadImages } from 'n-image';
 import * as serviceWorker from 'n-service-worker';
+import * as syndication from '../../syndication';
 
 export const presets = {
 	discrete: {
@@ -31,7 +32,8 @@ export const presets = {
 		subscriptionOfferPrompt: true,
 		myft: true,
 		ads: true,
-		tooltip: true
+		tooltip: true,
+		syndication: true
 	}
 };
 
@@ -183,6 +185,11 @@ export class ComponentInitializer {
 							flags
 						});
 						this.initializedFeatures.myftUi = true;
+					}
+
+					if (config.features.syndication && !this.initializedFeatures.syndication){
+						syndication.init(flags);
+						this.initializedFeatures.syndication = true;
 					}
 				});
 

--- a/main.js
+++ b/main.js
@@ -45,6 +45,8 @@ import * as subscriptionOfferPrompt from './subscription-offer-prompt';
 export const _subscriptionOfferPrompt = subscriptionOfferPrompt;
 import * as tooltip from './tooltip';
 export const _tooltip = tooltip;
+import * as syndication from './syndication';
+export const _syndication = syndication;
 
 // Export some third party components we're unlikely to remove in a hurry
 import ftdomdelegate from 'ftdomdelegate';

--- a/syndication/index.js
+++ b/syndication/index.js
@@ -1,0 +1,60 @@
+import {$$, cookieStore} from '../utils';
+
+const USER_PRODUCTS_SERVICE_URL = 'https://session-next.ft.com/products';
+const SYNDICATION_PRODUCT_CODE = 'S1';
+const SYNDICATION_USER_ATTR = 'data-syndication-user';
+
+const createSyndicationLink = uuid => {
+	const a = document.createElement('a');
+	a.href = `http://ftsyndication.com/redirect.php?uuid=${uuid}`;
+	a.target = '_blank';
+	a.classList.add('o-teaser__syndication-indicator');
+	a.innerHTML = '<span>Download Article (opens in a new window)</span>';
+	return a;
+};
+
+function checkIfUserisSyndicationCustomer (){
+	const user = cookieStore.user();
+	if(user){
+		return Promise.resolve(user.products().includes('S1'));
+	}
+
+	return fetch(USER_PRODUCTS_SERVICE_URL, {credentials:'include'})
+		.then(response => {
+			if(!response.ok){
+				throw new Error(`${USER_PRODUCTS_SERVICE_URL} returned ${response.status} ${response.statusText}`);
+			}else{
+				return response.json();
+			}
+		})
+		.then(json => {
+			return (json.products && json.products.includes(SYNDICATION_PRODUCT_CODE));
+		})
+}
+
+export function init (flags){
+	if(!flags.get('syndication')){
+		return;
+	}
+
+	const syndicatableArticles = $$('.o-teaser--syndicatable');
+
+	if(!syndicatableArticles.length){
+		return;
+	}
+
+	checkIfUserisSyndicationCustomer()
+		.then(userIsSyndicationCustomer => {
+			if(!userIsSyndicationCustomer){
+				return;
+			}
+
+			document.body.setAttribute(SYNDICATION_USER_ATTR, 'true');
+			syndicatableArticles.forEach(article => {
+				const heading = article.querySelector('.o-teaser__heading');
+				const link = heading.querySelector('a');
+				const uuid = link.pathname.replace('/content/', '');
+				heading.insertBefore(createSyndicationLink(uuid), link);
+			})
+		})
+}

--- a/syndication/main.scss
+++ b/syndication/main.scss
@@ -1,0 +1,38 @@
+@if nUiApply('syndication') {
+
+	.o-teaser__syndication-indicator {
+		display: none;
+		width: 12px;
+		height: 12px;
+		margin-right: 5px;
+
+		&:after {
+			content: 'Download';
+			color: white;
+			background-color: rgba(0, 0, 0, 0.6);
+			padding: 5px;
+			border-radius: 5px;
+			position: absolute;
+			display: none;
+			font-size: 16px;
+		}
+
+		&:hover:after {
+			display: block;
+		}
+	}
+
+	.o-teaser--hero .o-teaser__syndication-indicator {
+		width: 16px;
+		height: 16px;
+	}
+
+	.o-teaser--top-story .o-teaser__syndication-indicator {
+		width: 18px;
+		height: 18px;
+	}
+
+	[data-syndication-user] .o-teaser__syndication-indicator {
+		display: inline-block;
+	}
+}

--- a/utils/js/cookies.js
+++ b/utils/js/cookies.js
@@ -38,4 +38,24 @@ function remove (name){
 	return set(name, '', {expires:new Date(0)});
 }
 
-module.exports = {get, set, has, getRegexForName, remove};
+function user (){
+	const userCookie = get('FT_User');
+	const userCookieValue = name => {
+		if(!userCookie){
+			return '';
+		}
+
+		const result = new RegExp(`${name}=([^:]+)`).exec(userCookie);
+		if(!result || result.length < 2){
+			return '';
+		}
+
+		return result[1];
+	};
+
+	return {
+		products: () => userCookieValue('PRODUCTS')
+	}
+}
+
+module.exports = {get, set, has, getRegexForName, remove, user};

--- a/utils/test/cookie.spec.js
+++ b/utils/test/cookie.spec.js
@@ -42,4 +42,17 @@ describe('Cookie Utils', () => {
 		expect(cookieStore.has(name)).to.be.true;
 		expect(cookieStore.get(name)).to.equal(value);
 	});
+
+	context('User', () => {
+
+		before(() => {
+			cookieStore.set('FT_User', 'USERID=4011624548:EMAIL=paul.i.wilson@ft.com:FNAME=Paul:LNAME=Wilson:TIME=%5BTue%2C+10-Jan-2017+14%3A22%3A14+GMT%5D:USERNAME=paul.i.wilson@ft.com:REMEMBER=_REMEMBER_:ERIGHTSID=11624548:PRODUCTS=_Tools_S1_P0_P2_:RESOURCES=:GROUPS=:X=');
+		});
+
+		it('Should be able to get a user\'s products', () => {
+			const user = cookieStore.user();
+			const products = user.products();
+			expect(products).to.equal('_Tools_S1_P0_P2_')
+		})
+	})
 });


### PR DESCRIPTION
@lc512k 
@tavvy 

If it finds articles that are marked as available to syndication it checks the users products (first in the cookie, or via session-next) to see if they are a syndication customer.  If they are a green tick is added, which is a link to download the article on the syndication platform.

![screen shot 2017-01-10 at 17 36 42](https://cloud.githubusercontent.com/assets/18816/21817206/f7bb02a8-d75a-11e6-98ef-e030264798dd.png)
