### PR TITLE
Stop n-makefile from clobbering over .pa11yci.js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,4 +20,3 @@
 key.pem
 key-cert.pem
 /test-page.html
-.pa11yci.js


### PR DESCRIPTION
Still not sure why it’s happening now though, and not before

@wheresrhys 