### PR TITLE
Latest o-viewport

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -41,7 +41,7 @@
     "o-tracking": "^1.1.8",
     "o-typography": "^4.2.0",
     "o-video": "^2.3.21",
-    "o-viewport": "^2.0.0",
+    "o-viewport": "^3.2.0",
     "o-visual-effects": ">=0.1.0 < 2.0.0",
     "superstore": "^2.1.0",
     "superstore-sync": "^2.1.1"


### PR DESCRIPTION
Difference between v2 and 3 is the throttle and debounce functions moving out to o-utils (https://github.com/Financial-Times/o-viewport/releases/tag/v3.0.0), which we don't use anyway