### PR TITLE
Looser o-viewport dependency

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -41,7 +41,7 @@
     "o-tracking": "^1.1.8",
     "o-typography": "^4.2.0",
     "o-video": "^2.3.21",
-    "o-viewport": "^3.0.2",
+    "o-viewport": ">= 2.0.0 < 4.0.0",
     "o-visual-effects": ">=0.1.0 < 2.0.0",
     "superstore": "^2.1.0",
     "superstore-sync": "^2.1.1"
@@ -49,6 +49,6 @@
   "resolutions": {
     "o-icons": "^5.2.0",
     "o-visual-effects": "^1.0.0",
-    "o-viewport": "^3.0.2"
+    "o-viewport": "^3.0.1"
   }
 }


### PR DESCRIPTION
Keeping the resolution so n-ui builds, but hopefully all the apps without o-video should now build properly.

@ironsidevsquincy @wheresrhys 