### PR TITLE
Use v4 of o-expander

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -31,7 +31,7 @@
     "o-cookie-message": "^2.0.0",
     "o-date": "^2.7.0",
     "o-errors": "v3.5.0",
-    "o-expander": "^3.0.1",
+    "o-expander": "^4.2.2",
     "o-footer": "^5.0.0",
     "o-forms": "^2.0.0",
     "o-grid": "^4.2.0",


### PR DESCRIPTION
Was a major release, but only because its dependency's versions changed - https://github.com/Financial-Times/o-expander/pull/31/files