### PR TITLE
Update scroll depth implementation to match article, and add attentio…

### DIFF
--- a/_test-server/client/main.js
+++ b/_test-server/client/main.js
@@ -1,3 +1,6 @@
 import {bootstrap} from '../../main';
+const tracking = require('../../tracking');
 
-bootstrap({preset: 'complete'});
+bootstrap({preset: 'complete'}, () => {
+	tracking.scrollDepth.init('n-ui-test');
+});

--- a/_test-server/client/main.scss
+++ b/_test-server/client/main.scss
@@ -6,3 +6,7 @@ $n-ui-output-critical: true;
 );
 
 @import '../../bootstrap';
+
+body {
+	position: relative; //required for scroll depth markers to work
+}

--- a/tracking/ft/events/page-attention.js
+++ b/tracking/ft/events/page-attention.js
@@ -70,23 +70,19 @@ class Attention {
 		}
 	}
 
+	get () {
+		//getter should restart attention capturing as endAttention updates the value:
+		this.endAttention();
+		this.startAttention();
+		return this.totalAttentionTime;
+	}
+
 	addVideoEvents () {
-		this.videoPlayers;
-		if (window.FTVideo) {
-			this.videoPlayers = document.getElementsByClassName('BrightcoveExperience');
-			for (let i = 0; i < this.videoPlayers.length; i++) {
-				window.FTVideo.createPlayerAsync(this.videoPlayers[i].id, function (player) {
-					player.on(player.MEDIA_PLAY_EVENT, ev => this.startConstantAttention(ev));
-					player.on(player.MEDIA_STOP_EVENT, ev => this.endConstantAttention(ev));
-				});
-			}
-		} else {
-			this.videoPlayers = document.getElementsByTagName('video');
-			for (let i = 0; i < this.videoPlayers.length; i++) {
-				this.videoPlayers[i].addEventListener('playing', ev => this.startConstantAttention(ev));
-				this.videoPlayers[i].addEventListener('pause', ev => this.endConstantAttention(ev));
-				this.videoPlayers[i].addEventListener('ended', ev => this.endConstantAttention(ev));
-			}
+		this.videoPlayers = document.getElementsByTagName('video');
+		for (let i = 0; i < this.videoPlayers.length; i++) {
+			this.videoPlayers[i].addEventListener('playing', ev => this.startConstantAttention(ev));
+			this.videoPlayers[i].addEventListener('pause', ev => this.endConstantAttention(ev));
+			this.videoPlayers[i].addEventListener('ended', ev => this.endConstantAttention(ev));
 		}
 	}
 

--- a/tracking/ft/events/page-attention.js
+++ b/tracking/ft/events/page-attention.js
@@ -31,7 +31,7 @@ class Attention {
 
 		// Add event to send data on unload
 		EXIT_EVENTS.forEach(event => {
-			window.addEvendtListener(event, () => {
+			window.addEventListener(event, () => {
 				if(this.hasSentEvent) {
 					return;
 				}

--- a/tracking/ft/events/page-attention.js
+++ b/tracking/ft/events/page-attention.js
@@ -3,13 +3,14 @@ const broadcast = require('../../../utils').broadcast;
 const ATTENTION_INTERVAL = 15000;
 const ATTENTION_EVENTS = ['load', 'click', 'focus', 'scroll', 'mousemove', 'touchstart', 'touchend', 'touchcancel', 'touchleave'];
 const UNATTENTION_EVENTS = ['blur'];
-const eventToSend = ('onbeforeunload' in window) ? 'beforeunload' : 'unload';
+const EXIT_EVENTS = ['beforeunload', 'unload', 'pagehide'];
 
 class Attention {
 	constructor () {
 		this.totalAttentionTime = 0;
 		this.startAttentionTime;
 		this.endAttentionTime;
+		this.hasSentEvent = false;
 	}
 
 	init () {
@@ -29,16 +30,22 @@ class Attention {
 		this.addVideoEvents();
 
 		// Add event to send data on unload
-		window.addEventListener(eventToSend, () => {
-			this.endAttention();
-			broadcast('oTracking.event', {
-				category: 'page',
-				action: 'interaction',
-				context: {
-					attention: {
-						total: this.totalAttentionTime
-					}
+		EXIT_EVENTS.forEach(event => {
+			window.addEvendtListener(event, () => {
+				if(this.hasSentEvent) {
+					return;
 				}
+				this.hasSentEvent = true;
+				this.endAttention();
+				broadcast('oTracking.event', {
+					category: 'page',
+					action: 'interaction',
+					context: {
+						attention: {
+							total: this.totalAttentionTime
+						}
+					}
+				});
 			});
 		});
 

--- a/tracking/index.js
+++ b/tracking/index.js
@@ -10,6 +10,7 @@ module.exports = {
 			require('./third-party/sourcepoint')(flags);
 		});
 	},
-	scrollDepthComponents: require('./ft/events/scroll-depth-components')
+	scrollDepthComponents: require('./ft/events/scroll-depth-components'),
+	scrollDepth: require('./ft/events/scroll-depth')
 
 };


### PR DESCRIPTION
**What**
* Update the scroll depth tracking (which looks like it wasn't actually used anywhere) into something that matches the implementation in the article
* Add the current attention time as a property on that scroll depth event
* Remove old FT.com video code from the attention time stuff*

**Why**

The attention time tracking is quite unreliable in it's sending (beforeUnload and unload don't always work and it's hard to get something that does reliably work) - so attaching the current time onto scroll depth provides a way to get _some_ more reliable data, while not perfect (it only captures on the first scroll).

It also potentially provides some interesting insights i.e. you can see what portion of the page people spend the most time on.

The intention will be to make the article use this instead of it's own.

@ironsidevsquincy @TheoLeanse @wheresrhys @adambraimbridge @tom-parker 