### PR TITLE
Remove: Front Page Fast FT Journey flag reference

### DIFF
--- a/header/partials/header/nav_v2.html
+++ b/header/partials/header/nav_v2.html
@@ -1,4 +1,4 @@
-{{#ifAll @root.flags.frontPageFastFTJourney @root.navigation.menus.navbar-simple}}
+{{#if @root.navigation.menus.navbar-simple}}
 	<nav id="o-header-nav-mobile" class="o-header__row o-header__nav o-header__nav--mobile" aria-hidden="true" data-trackable="header-nav:mobile">
 		<ul class="o-header__nav-list">
 			{{#each @root.navigation.menus.navbar-simple.items}}
@@ -8,7 +8,7 @@
 			{{/each}}
 		</ul>
 	</nav>
-{{/ifAll}}
+{{/if}}
 
 <nav id="o-header-nav-desktop" class="o-header__row o-header__nav o-header__nav--desktop" role="navigation" aria-label="Primary navigation" data-trackable="header-nav:desktop">
 	<div class="o-header__container">


### PR DESCRIPTION
Given the flag was removed on 31 Jan 2017.

![screen shot 2017-02-06 at 11 09 32](https://cloud.githubusercontent.com/assets/10484515/22644987/c508e4a8-ec5c-11e6-970e-013660a4f5c9.png)
