### PR TITLE
don't show powr until lionel's been closed

### DIFF
--- a/n.Makefile
+++ b/n.Makefile
@@ -28,7 +28,7 @@ NPM_INSTALL = npm prune --production=false && npm install
 BOWER_INSTALL = bower prune && bower install --config.registry.search=http://registry.origami.ft.com --config.registry.search=https://bower.herokuapp.com
 JSON_GET_VALUE = grep $1 | head -n 1 | sed 's/[," ]//g' | cut -d : -f 2
 IS_GIT_IGNORED = grep -q $(if $1, $1, $@) .gitignore
-VERSION = v4
+VERSION = v5
 APP_NAME = $(shell cat package.json 2>/dev/null | $(call JSON_GET_VALUE,name))
 DONE = echo ✓ $@ done
 CONFIG_VARS = curl -fsL https://ft-next-config-vars.herokuapp.com/$1/$(call APP_NAME)$(if $2,.$2,) -H "Authorization: `heroku config:get APIKEY --app ft-next-config-vars`"

--- a/subscription-offer-prompt/pwr-of-you.js
+++ b/subscription-offer-prompt/pwr-of-you.js
@@ -5,22 +5,30 @@ import * as utils from './utils';
 import { broadcast } from '../utils';
 
 const promptLastSeenStorage = new Superstore('local', 'n-ui.subscription-offer-pwr-of-you');
+const lionelLastSeenStorage = new Superstore('local', 'n-ui.subscription-offer-prompt');
+
 const promptLastSeenStorageKey = 'last-closed-pwr';
+const lionelLastSeenStorageKey = 'last-closed';
 
 const getPromptLastClosed = () => promptLastSeenStorage.get(promptLastSeenStorageKey);
+
+const getLionelLastClosed = () => lionelLastSeenStorage.get(lionelLastSeenStorageKey);
 
 const setPromptLastClosed = () => promptLastSeenStorage.set(promptLastSeenStorageKey, Date.now());
 
 /**
  * Show the prompt if
  *	* the prompt has not been closed, or was last closed more than 30 days ago
- *	* usElection2016DiscountSlider flag is true
+ *	* PowrOfYouSlider flag is true
+ *	* The lionel slider has been closed at least once (lionelLastSeenStorageKey exists)
  */
 const shouldPromptBeShown = (flags) => {
-	return getPromptLastClosed()
-		.then(promptLastClosed => {
-			return (!promptLastClosed || promptLastClosed + (1000 * 60 * 60 * 24 * 30) <= Date.now()) && flags.get('PowerOfYouSlider');
-		})
+	return Promise.all([
+			getPromptLastClosed(),
+			getLionelLastClosed(),
+		]).then(([promptLastClosed, lionelLastClosed]) => {
+			return !!lionelLastClosed && (!promptLastClosed || promptLastClosed + (1000 * 60 * 60 * 24 * 30) <= Date.now()) && flags.get('PowerOfYouSlider');
+		});
 };
 
 const popupTemplate = () => `


### PR DESCRIPTION
@jkerr321 this will ensure we don't show the powr slider until lionel has been closed. Sound ok?