### PR TITLE
force hiding of myft bits until loaded

### DIFF
--- a/myft-common/main.scss
+++ b/myft-common/main.scss
@@ -94,6 +94,16 @@
 		width: 34px;
 		margin: 0 8px -5px;
 	}
+
+	// shouldn't really be in here, but a temporary hack while n-ui styles are on the move
+	.myft-hint {
+		display: none;
+	}
+
+	.n-myft-digest-promo {
+		display: none;
+	}
+
 	@include nUiStylesheetEnd('head-n-ui-core');
 }
 

--- a/myft-digest-promo/main.scss
+++ b/myft-digest-promo/main.scss
@@ -1,10 +1,3 @@
-
-@include nUiStylesheet('head-n-ui-core') {
-	.n-myft-digest-promo {
-		display: none;
-	}
-};
-
 $icon-width-s: 90px;
 $icon-width-m: 90px;
 

--- a/myft-hint/main.scss
+++ b/myft-hint/main.scss
@@ -1,9 +1,3 @@
-@include nUiStylesheet('head-n-ui-core') {
-	.myft-hint {
-		display: none;
-	}
-};
-
 @keyframes bounce {
 	from {
 		right: 90px;


### PR DESCRIPTION
@adambraimbridge 

That was a tricky one. Basically, only stylesheets output in n-ui by default should reference the `head-n-ui-core` stylesheet