### PR TITLE
Enable tracking to be disabled on footer link clicks

### DIFF
--- a/footer/template.html
+++ b/footer/template.html
@@ -13,7 +13,7 @@
 						{{#each submenu.items}}
 						<div class="o-footer__matrix-column">
 							{{#each this}}
-							<a class="o-footer__matrix-link" href="{{url}}" data-trackable="{{label}}" {{#disableTracking?}}data-o-tracking-do-not-track="true"{{/disableTracking?}}>{{{label}}}</a>
+							<a class="o-footer__matrix-link" href="{{url}}" data-trackable="{{label}}" {{#disableTracking}}data-o-tracking-do-not-track="true"{{/disableTracking}}>{{{label}}}</a>
 							{{/each}}
 						</div>
 						{{/each}}

--- a/footer/template.html
+++ b/footer/template.html
@@ -13,7 +13,7 @@
 						{{#each submenu.items}}
 						<div class="o-footer__matrix-column">
 							{{#each this}}
-							<a class="o-footer__matrix-link" href="{{url}}" data-trackable="{{label}}">{{{label}}}</a>
+							<a class="o-footer__matrix-link" href="{{url}}" data-trackable="{{label}}" {{#disableTracking?}}data-o-tracking-do-not-track="true"{{/disableTracking?}}>{{{label}}}</a>
 							{{/each}}
 						</div>
 						{{/each}}


### PR DESCRIPTION
This change is related to Financial-Times/o-tracking#153 enabling a data attribute to be added which disables click event tracking for certain links (when tagged with the new data attribute data-o-tracking-do-not-track)