### PR TITLE
[FIX] [pa11y] sticky nav for anon users

### DIFF
--- a/components/n-ui/header/partials/header/sticky.html
+++ b/components/n-ui/header/partials/header/sticky.html
@@ -38,7 +38,7 @@
 					{{#unlessEquals nUi.header.userNav false}}
 						<div class="o-header__nav">
 							<ul class="o-header__nav-list o-header__nav-list--right" data-trackable="user-nav">
-								{{#each @root.navigation.menus.navbar-right-anon}}
+								{{#each @root.navigation.menus.navbar-right-anon.items}}
 									<li class="o-header__nav-item">
 										<a class="o-header__nav-link" href="{{url}}" data-trackable="{{label}}" tabindex="-1">{{label}}</a>
 									</li>


### PR DESCRIPTION
Fixes:
- <a> tags with no content or href
- missing 'Subscribe' and 'Sign in' buttons for anonymous users