### PR TITLE
Add new syndication download links (flagged)

### DIFF
--- a/components/n-ui/syndication/index.js
+++ b/components/n-ui/syndication/index.js
@@ -1,40 +1,83 @@
 import {$$, $} from 'n-ui-foundations';
+import {products as getUserProducts, uuid as getUuid} from 'next-session-client';
+import newSyndicators from './new-synders';
 
-import {products as getUserProducts} from 'next-session-client';
 const SYNDICATION_PRODUCT_CODE = 'S1';
 const SYNDICATION_USER_ATTR = 'data-syndication-user';
 const SYNDICATION_LINK_CLASS = 'o-teaser__syndication-indicator';
 const TEASER_SELECTOR = '.o-teaser--syndicatable, .o-teaser--not-syndicatable';
 
-const createSyndicationLink = (uuid, syndicationStatus) => {
+const downloadableFormats = [
+	{
+		type: 'html',
+		name: 'HTML'
+	},
+	{
+		type: 'docx',
+		name: 'Word doc'
+	},
+	{
+		type: 'plain',
+		name: 'plain text'
+	}
+];
+
+const createSyndicationLinkOld = (uuid, title, syndicationStatus) => {
 	const a = document.createElement('a');
 	a.href = `http://ftsyndication.com/redirect.php?uuid=${uuid}`;
 	a.target = '_blank';
 	a.rel = 'noopener';
 	a.classList.add(SYNDICATION_LINK_CLASS);
 	a.classList.add(SYNDICATION_LINK_CLASS+'--'+syndicationStatus);
-	a.innerHTML = '<span>Download Article (opens in a new window)</span>';
+	a.innerHTML = `<span>Download “${title || 'article'}” (opens in a new window)</span>`;
 	return a;
 };
 
-function checkIfUserIsSyndicationCustomer (){
+const createSyndiLinkNew = (data) => (`
+	<a href="https://ft-rss.herokuapp.com/content/${data.uuid}?format=${data.format.type}&download=true" class="syndi__link n-skip-link" data-trackable="download-${data.format.type}">Download <span class="n-util-visually-hidden">${data.title} </span>as ${data.format.name}</a>
+`);
+
+const createSyndiOverlay = (data) => {
+	const syndiLinks = downloadableFormats.map(format => createSyndiLinkNew(Object.assign({}, data, { format })));
+	return `
+		<p class="n-util-visually-hidden">This blah blah but put this afterwards!</p>
+		<div class="syndi__download-options">
+			${syndiLinks.join('\n\t')}
+		</div>
+	`;
+};
+
+const createSyndicatorNew = (uuid, title, syndicationStatus) => {
+	const container = document.createElement('div');
+
+	container.className = [
+		SYNDICATION_LINK_CLASS,
+		`${SYNDICATION_LINK_CLASS}--${syndicationStatus}`,
+		'syndi'
+	].join(' ');
+	container.setAttribute('data-trackable', 'syndication');
+	container.innerHTML = createSyndiOverlay({ uuid, title });
+
+	return container;
+};
+
+function checkIfUserIsSyndicationCustomer () {
+	let userIsSyndicationCustomer = false;
 	return getUserProducts()
 		.then(response => {
-			if(!response || !response.products){
-				return false;
-			}else{
-				return response.products.includes(SYNDICATION_PRODUCT_CODE);
+			if (response && response.products) {
+				userIsSyndicationCustomer = response.products.includes(SYNDICATION_PRODUCT_CODE);
 			}
-		}).catch(() => {
-			return false;
-	});
+		})
+		.catch(err => err)
+		.then(() => userIsSyndicationCustomer);
 }
 
-function updateTeasers (teasers){
-	teasers.forEach(updateTeaser);
+function updateTeasers (teasers, createSyndicator){
+	teasers.forEach(teaser => updateTeaser(teaser, createSyndicator));
 }
 
-function updateTeaser (teaser){
+function updateTeaser (teaser, createSyndicator){
 	const syndicationStatus = teaser.classList.contains('o-teaser--syndicatable') ? 'yes' : 'no';
 	const heading = teaser.querySelector('.o-teaser__heading');
 	if(heading.querySelector('.'+SYNDICATION_LINK_CLASS)){
@@ -42,15 +85,16 @@ function updateTeaser (teaser){
 	}
 	const link = heading.querySelector('a');
 	const uuid = link.pathname.replace('/content/', '');
-	heading.insertBefore(createSyndicationLink(uuid, syndicationStatus), link);
+	const title = link.textContent;
+	heading.insertBefore(createSyndicator(uuid, title, syndicationStatus), link);
 }
 
-function updateMainArticle (article){
+function updateMainArticle (article, createSyndicator){
 	const syndicationStatus = article.getAttribute('data-syndicatable');
 	const container = article.querySelector('.article-headline');
 	const title = container.querySelector('.article-classifier__gap');
 	const uuid = article.getAttribute('data-content-id');
-	container.insertBefore(createSyndicationLink(uuid, syndicationStatus), title);
+	container.insertBefore(createSyndicator(uuid, title, syndicationStatus), title);
 }
 
 function onAsyncContentLoaded (){
@@ -72,6 +116,7 @@ export function init (flags){
 
 	document.body.addEventListener('asyncContentLoaded', onAsyncContentLoaded);
 
+	//TODO: refactor this pyramid away
 	checkIfUserIsSyndicationCustomer()
 		.then(userIsSyndicationCustomer => {
 			if(!userIsSyndicationCustomer){
@@ -79,12 +124,23 @@ export function init (flags){
 			}
 
 			document.body.setAttribute(SYNDICATION_USER_ATTR, 'true');
-			if(syndicatableTeasers.length){
-				updateTeasers(syndicatableTeasers);
-			}
 
-			if(syndicatableMainArticle){
-				updateMainArticle(syndicatableMainArticle);
-			}
+			let shouldUseNewSyndication = false;
+
+			getUuid().then(({uuid} = {}) => {
+				shouldUseNewSyndication = (flags.get('syndicationNew') && newSyndicators.includes(uuid)) || flags.get('syndicationNewOverride');
+			})
+			.catch(err => err) // Show old syndicator if anything goes wrong
+			.then(() => {
+				const createSyndicator = (shouldUseNewSyndication) ? createSyndicatorNew : createSyndicationLinkOld;
+
+				if(syndicatableTeasers.length){
+					updateTeasers(syndicatableTeasers, createSyndicator);
+				}
+
+				if(syndicatableMainArticle){
+					updateMainArticle(syndicatableMainArticle, createSyndicator);
+				}
+			});
 		});
 }

--- a/components/n-ui/syndication/index.js
+++ b/components/n-ui/syndication/index.js
@@ -34,7 +34,7 @@ const createSyndicationLinkOld = (uuid, title, syndicationStatus) => {
 };
 
 const createSyndiLinkNew = (data) => (`
-	<a href="https://ft-rss.herokuapp.com/content/${data.uuid}?format=${data.format.type}&download=true" class="syndi__link n-skip-link" data-trackable="download-${data.format.type}">Download <span class="n-util-visually-hidden">${data.title} </span>as ${data.format.name}</a>
+	<a href="https://ft-rss.herokuapp.com/content/${data.uuid}?format=${data.format.type}&download=true" class="syndi__link n-skip-link" data-trackable="download-${data.format.type}">Download <span class="n-util-visually-hidden">“${data.title}” </span>as ${data.format.name}</a>
 `);
 
 const createSyndiOverlay = (data) => {

--- a/components/n-ui/syndication/index.js
+++ b/components/n-ui/syndication/index.js
@@ -10,6 +10,7 @@ const createSyndicationLink = (uuid, syndicationStatus) => {
 	const a = document.createElement('a');
 	a.href = `http://ftsyndication.com/redirect.php?uuid=${uuid}`;
 	a.target = '_blank';
+	a.rel = 'noopener';
 	a.classList.add(SYNDICATION_LINK_CLASS);
 	a.classList.add(SYNDICATION_LINK_CLASS+'--'+syndicationStatus);
 	a.innerHTML = '<span>Download Article (opens in a new window)</span>';

--- a/components/n-ui/syndication/index.js
+++ b/components/n-ui/syndication/index.js
@@ -97,9 +97,9 @@ function updateMainArticle (article, createSyndicator){
 	container.insertBefore(createSyndicator(uuid, title, syndicationStatus), title);
 }
 
-function onAsyncContentLoaded (){
+function onAsyncContentLoaded (createSyndicator){
 	const syndicatableTeasers = $$(TEASER_SELECTOR);
-	updateTeasers(syndicatableTeasers);
+	updateTeasers(syndicatableTeasers, createSyndicator);
 }
 
 export function init (flags){
@@ -113,8 +113,6 @@ export function init (flags){
 	if(!syndicatableTeasers.length && !syndicatableMainArticle){
 		return;
 	}
-
-	document.body.addEventListener('asyncContentLoaded', onAsyncContentLoaded);
 
 	//TODO: refactor this pyramid away
 	checkIfUserIsSyndicationCustomer()
@@ -133,6 +131,8 @@ export function init (flags){
 			.catch(err => err) // Show old syndicator if anything goes wrong
 			.then(() => {
 				const createSyndicator = (shouldUseNewSyndication) ? createSyndicatorNew : createSyndicationLinkOld;
+
+				document.body.addEventListener('asyncContentLoaded', () => onAsyncContentLoaded(createSyndicator));
 
 				if(syndicatableTeasers.length){
 					updateTeasers(syndicatableTeasers, createSyndicator);

--- a/components/n-ui/syndication/index.js
+++ b/components/n-ui/syndication/index.js
@@ -40,7 +40,6 @@ const createSyndiLinkNew = (data) => (`
 const createSyndiOverlay = (data) => {
 	const syndiLinks = downloadableFormats.map(format => createSyndiLinkNew(Object.assign({}, data, { format })));
 	return `
-		<p class="n-util-visually-hidden">This blah blah but put this afterwards!</p>
 		<div class="syndi__download-options">
 			${syndiLinks.join('\n\t')}
 		</div>

--- a/components/n-ui/syndication/main.scss
+++ b/components/n-ui/syndication/main.scss
@@ -65,7 +65,7 @@
 	}
 }
 
-// Only works for curserable-folks because we’re in hell
+// Only works for cursorable-folks because we’re in hell
 .syndi:hover {
 	// Override existing syndication styling
 	// (We’re doing a staggered roll-out of new syndication)

--- a/components/n-ui/syndication/main.scss
+++ b/components/n-ui/syndication/main.scss
@@ -9,7 +9,7 @@
 	&:after {
 		content: 'Download';
 		color: white;
-		background-color: rgba(0, 0, 0, 0.6);
+		background-color: rgba(0, 0, 0, 0.85);
 		padding: 5px;
 		border-radius: 5px;
 		position: absolute;

--- a/components/n-ui/syndication/main.scss
+++ b/components/n-ui/syndication/main.scss
@@ -43,7 +43,7 @@
 
 .syndi__download-options {
 	@include nUiZIndexFor('overlay');
-	background-color: rgba(black, .85);
+	background-color: rgba(black, 0.85);
 	border-radius: 5px;
 	color: white;
 	font-size: 16px;

--- a/components/n-ui/syndication/main.scss
+++ b/components/n-ui/syndication/main.scss
@@ -40,3 +40,50 @@
 [data-syndication-user] .o-teaser__syndication-indicator {
 	display: inline-block;
 }
+
+.syndi__download-options {
+	@include nUiZIndexFor('overlay');
+	background-color: rgba(black, .85);
+	border-radius: 5px;
+	color: white;
+	font-size: 16px;
+	padding: 5px 0;
+	position: absolute;
+	text-align: left;
+}
+
+.syndi__link {
+	display: block;
+	padding: 5px 10px;
+
+	// Override n-skip-link styling
+	// (Using n-skip-link lets keyboard-navigating folks use syndication)
+	&:hover,
+	&:focus {
+		background: black;
+		position: static;
+	}
+}
+
+// Only works for curserable-folks because we’re in hell
+.syndi:hover {
+	// Override existing syndication styling
+	// (We’re doing a staggered roll-out of new syndication)
+	&:after {
+		display: none;
+	}
+
+	// Override n-skip-link styling
+	// (Using n-skip-link lets keyboard-navigating folks use syndication)
+	// Note this duplication is currently required (including the non-hover
+	// one further up)
+	.syndi__link {
+		background: transparent;
+		position: static;
+	}
+	.syndi__link:hover,
+	.syndi__link:focus {
+		background: black;
+		position: static;
+	}
+}

--- a/components/n-ui/syndication/new-synders.js
+++ b/components/n-ui/syndication/new-synders.js
@@ -1,0 +1,3 @@
+export default [
+	'43d06a9a-5c72-4273-8738-b5cf26fa75b7'
+];


### PR DESCRIPTION
Shows syndication links visually similar to the existing ones, but:
- we manage the syndication downloads rather than linking to a third party
- users can download the article without being taken elsewhere to log in
- users can download in docx format (not available in third party system)
- keyboard and screenreader users _can_ use it 🎉  (although still probably quite confusing)

The UI still looks the same (with several UX issues) while we track how many people are actually using syndication (we had no tracking before, it seems 😱 )

## Cursor-using folks

Before | After
---|---
![cursor-before](https://cloud.githubusercontent.com/assets/150157/24353485/a7c481cc-12e5-11e7-8675-53fdeecf2c54.gif) | ![cursor-after](https://cloud.githubusercontent.com/assets/150157/24353515/ccce2932-12e5-11e7-83d9-41ed5a020faf.gif)

## Keyboard-navigating folks

Before | After
---|---
![keyboard-before](https://cloud.githubusercontent.com/assets/150157/24353799/3884c75c-12e7-11e7-8a93-438994ea372f.gif) 😢  | ![keyboard-after](https://cloud.githubusercontent.com/assets/150157/24353800/3c88b188-12e7-11e7-8655-3006193cf2fe.gif) `¯\_(ツ)_/¯ better than nothing?`

## Screenreader links lists

Before | After
---|---
![screenreader-before](https://cloud.githubusercontent.com/assets/150157/24356511/39653f16-12f2-11e7-98f3-44be6030ab63.png) | ![screenreader-after](https://cloud.githubusercontent.com/assets/150157/24356543/5b3b378a-12f2-11e7-8c03-3d59876dcfd7.png)

Tested and working in Chrome and Firefox. Note this UI is pretty broken for touch users but we’ll be redesigning (mobile first) soon.

@Thurst-ft 