### PR TITLE
Add: Anonymous user pa11y scenarios

### DIFF
--- a/components/n-ui/header/pa11y-config.js
+++ b/components/n-ui/header/pa11y-config.js
@@ -22,6 +22,28 @@ module.exports = {
 					'FT-Flags': 'ads:off,javascript:off'
 				}
 			}
+		},
+		{
+			rootElement: '.n-layout__row--header',
+			// Hide elements that depend on other components’ markup
+			hideElements: '.n-skip-link, [href="#o-header-drawer"]',
+			page: {
+				headers: {
+					'FT-Anonymous-User': true,
+					'FT-Flags': 'ads:off,javascript:on'
+				}
+			}
+		},
+		{
+			rootElement: '.n-layout__row--header',
+			// Hide elements that depend on other components’ markup
+			hideElements: '.n-skip-link, [href="#o-header-drawer"]',
+			page: {
+				headers: {
+					'FT-Anonymous-User': true,
+					'FT-Flags': 'ads:off,javascript:off'
+				}
+			}
 		}
 	]
 };


### PR DESCRIPTION
Prevents regression of this fix: https://github.com/Financial-Times/n-ui/pull/886

If this fix were undone, the pa11y tests would fail on the basis of: `Anchor element found with no link content and no name and/or ID attribute.`