### PR TITLE
Apply: o-header for sticky header anon user links

### DIFF
--- a/components/n-ui/header/partials/header/sticky.html
+++ b/components/n-ui/header/partials/header/sticky.html
@@ -39,8 +39,15 @@
 						<div class="o-header__nav">
 							<ul class="o-header__nav-list o-header__nav-list--right" data-trackable="user-nav">
 								{{#each @root.navigation.menus.navbar-right-anon.items}}
-									<li class="o-header__nav-item">
-										<a class="o-header__nav-link" href="{{url}}" data-trackable="{{label}}" tabindex="-1">{{label}}</a>
+									<li class="o-header__nav-item {{#ifEquals label 'Subscribe'}}o-header__nav-item--expanded{{/ifEquals}}">
+										<a
+											class="o-header__nav-{{#ifEquals label 'Subscribe'}}button{{else}}link{{/ifEquals}}"
+											href="{{url}}"
+											data-trackable="{{label}}"
+											tabindex="-1"
+										>
+											{{label}}
+										</a>
 									</li>
 								{{/each}}
 							</ul>


### PR DESCRIPTION
`Sign In` and `Subscribe` links should behave as they do on `o-header` demo (confirmed with Sue Vago): https://www.ft.com/__origami/service/build/v2/demos/o-header@6.14.1/sticky-header

These changes give those links the same styling and show/hide logic.