### PR TITLE
[FIX] added tab focus on offer popup

### DIFF
--- a/components/n-ui/subscription-offer-prompt/index.js
+++ b/components/n-ui/subscription-offer-prompt/index.js
@@ -28,12 +28,9 @@ const isLoggedIn = utils.getCookie('FTSession');
 /*
 @param {Object} flags -
 */
-// TODO a11y:
-// move focus to any pop up
-// make ESC close it and go back to previous focused element
+// TODO a11y: move focus to _any_ pop up
 export default function init (flags) {
 	const messagesEnabled = flags.get('b2cMessagePrompt');
-
 	if (isLoggedIn() || document.querySelector('.ft-subscription-panel') || !messagesEnabled || document.querySelector('.inline-barrier') || document.querySelector('.sub-header--fastft') ) {
 		return;
 	}

--- a/components/n-ui/subscription-offer-prompt/lionel.js
+++ b/components/n-ui/subscription-offer-prompt/lionel.js
@@ -84,7 +84,9 @@ const createSubscriptionPrompt = values => {
 	subscriptionPrompt.onClose = () => {
 		setPromptLastClosed();
 
-		if(focusedElementBeforePrompt !== undefined)	focusedElementBeforePrompt.focus();
+		if(focusedElementBeforePrompt !== undefined) {
+			focusedElementBeforePrompt.focus();
+		}
 		subscriptionPrompt.removeEventListener('keydown', trapTab);
 		focusableElements.forEach((elem) => {
 			elem.setAttribute('tabindex', '-1');
@@ -96,7 +98,7 @@ const createSubscriptionPrompt = values => {
 	let lastTabStop = focusableElements[focusableElements.length - 1];
 
 	const trapTab = (e) => {
-		if(e.keyCode === 9) {
+		if(e.keyCode === 9) { //TAB key
 			if(e.shiftKey) {
 				if(document.activeElement === firstTabStop) {
 					e.preventDefault();
@@ -110,7 +112,7 @@ const createSubscriptionPrompt = values => {
 			}
 		}
 
-		if(e.keyCode === 27) {
+		if(e.keyCode === 27) { //ESC key
 			slidingPopup.close();
 		}
 	};


### PR DESCRIPTION
- adds tab focus when popup open
- resumes focus when popup dismissed, set `tabindex` to `-1`
- option to dismiss pressing `ESC`