### PR TITLE
Amend: swap out h3 for div in search results heading

### DIFF
--- a/components/n-ui/typeahead/suggestion-list.js
+++ b/components/n-ui/typeahead/suggestion-list.js
@@ -32,7 +32,7 @@ export class SuggestionList extends React.Component {
 	}
 
 	renderHeading (group) {
-		return this.props.categories.length > 1 ? <h3 className="n-typeahead__heading">{group.heading}</h3> : '';
+		return this.props.categories.length > 1 ? <div className="n-typeahead__heading">{group.heading}</div> : '';
 	}
 
 	renderTailLink (group) {


### PR DESCRIPTION
cc: @lc512k 

The `<h3>` in the typeahead search results conflicts with the heading hierarchy of the page.

All styling is based on the class name, so replacement with a `<div>` should have no presentational impact.