### PR TITLE
Use: Div (not h3) tags for n-typeahead__heading class

### DIFF
--- a/components/n-ui/typeahead/suggestion-list.js
+++ b/components/n-ui/typeahead/suggestion-list.js
@@ -32,7 +32,7 @@ export class SuggestionList extends React.Component {
 	}
 
 	renderHeading (group) {
-		return this.props.categories.length > 1 ? <h3 className="n-typeahead__heading">{group.heading}</h3> : '';
+		return this.props.categories.length > 1 ? <div className="n-typeahead__heading">{group.heading}</div> : '';
 	}
 
 	renderTailLink (group) {


### PR DESCRIPTION
The typeahead component appears above the content `h1` tags in the DOM tree, so if any `h3` tags appear above it then pa11y with throw errors relating to structure:

`The heading structure is not logically nested. This h3 element appears to be the primary document heading, so should be an h1 element.`

Have edited HTML to make changes in this PR and still displays the same (i.e. styling is dependent on class alone and not which tags are used).

![screen shot 2017-04-04 at 15 08 35](https://cloud.githubusercontent.com/assets/10484515/24664257/1cc806de-1952-11e7-966b-bb8f9f5284cf.png)
