### PR TITLE
Fix: type ahead search suggestion in ie11

### DIFF
--- a/components/n-ui/typeahead/main.scss
+++ b/components/n-ui/typeahead/main.scss
@@ -50,7 +50,7 @@
 
 	.n-typeahead__group {
 		padding: $spacing-unit;
-		flex: 1;
+		flex: 1 auto;
 	}
 
 	.n-typeahead__item-list,


### PR DESCRIPTION
cc: @laurieboyes 
ie11 doesn't cope well with the minimal shorthand of flex, so added auto that applies to flex-basis.