### PR TITLE
force good version of o-header

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -27,7 +27,7 @@
     "o-cookie-message": "^2.0.0",
     "o-errors": "^3.5.1",
     "o-footer": "^5.0.0",
-    "o-header": "^6.10.0",
+    "o-header": "^6.14.2",
     "o-tracking": "^1.1.8",
     "n-ui-foundations": "^1.0.0",
     "o-expander": "^4.2.2",


### PR DESCRIPTION
bump version to the one where focus works well on the menu for VO on iOS