### PR TITLE
Remove source map strings from inlined css

### DIFF
--- a/server/lib/stylesheet-manager.js
+++ b/server/lib/stylesheet-manager.js
@@ -28,7 +28,8 @@ module.exports = {
 				if (!stylesheets[name]) {
 					throw new Error(`Stylesheet ${name}.css does not exist`);
 				}
-				return str + stylesheets[name];
+				// remove source maps from inlined css as browser will error
+				return str + stylesheets[name].replace(/\/\*# sourceMappingURL=.*\*\//, '');
 			}, '');
 			concatenatedStylesSizeCache[hash] = calculateSize(concatenatedStylesCache[hash])
 		}


### PR DESCRIPTION
Source maps do not work for inlined css. So when we concat
the stylesheets for inlining we now remove source map strings.