### PR TITLE
Add a more generic way to add the 'can be syndicated' flags

### DIFF
--- a/components/n-ui/syndication/README.md
+++ b/components/n-ui/syndication/README.md
@@ -25,3 +25,10 @@ Here we add an additional modifier if syndication is available on this article
 
 **next-article** - https://github.com/Financial-Times/next-article/blob/master/views/content.html#L20
 Here a data attribute is added containing the syndication status of the article.
+
+**generic** - add the following data attributes to your markup:
+
+* `data-syndicatable-uuid` – the uuid of the content to syndicate
+* `data-syndicatable-title` – the title of the content to syndicate
+* `data-syndicatable` – `yes` / `no` / `verify`
+* `data-syndicatable-target` – the element to insert the syndication flag

--- a/components/n-ui/syndication/index.js
+++ b/components/n-ui/syndication/index.js
@@ -97,6 +97,19 @@ function updateMainArticle (article, createSyndicator){
 	container.insertBefore(createSyndicator(uuid, title, syndicationStatus), title);
 }
 
+function updateGenerics (generics, createSyndicator){
+	generics.forEach(generic => updateGeneric(generic, createSyndicator));
+}
+
+function updateGeneric (container, createSyndicator){
+	const uuid = container.getAttribute('data-syndicatable-uuid');
+	const title = container.querySelector('[data-syndicatable-title]').innerHTML;
+	const syndicationStatus = container.getAttribute('data-syndicatable');
+	const target = container.querySelector('[data-syndicatable-target]');
+
+	target.parentNode.insertBefore(createSyndicator(uuid, title, syndicationStatus), target);
+}
+
 function onAsyncContentLoaded (createSyndicator){
 	const syndicatableTeasers = $$(TEASER_SELECTOR);
 	updateTeasers(syndicatableTeasers, createSyndicator);
@@ -110,7 +123,10 @@ export function init (flags){
 	const syndicatableTeasers = $$(TEASER_SELECTOR);
 	const syndicatableMainArticle = $('.article[data-syndicatable]');
 
-	if(!syndicatableTeasers.length && !syndicatableMainArticle){
+	// TODO: update article pages to use generic style?
+	const syndicatableGenerics = $$('[data-syndicatable]:not(.article)');
+
+	if(!syndicatableTeasers.length && !syndicatableMainArticle && !syndicatableGenerics.length){
 		return;
 	}
 
@@ -140,6 +156,10 @@ export function init (flags){
 
 				if(syndicatableMainArticle){
 					updateMainArticle(syndicatableMainArticle, createSyndicator);
+				}
+
+				if (syndicatableGenerics.length){
+					updateGenerics(syndicatableGenerics, createSyndicator);
 				}
 			});
 		});


### PR DESCRIPTION
Uses data attributes to allow a more flexible DOM structure:

`data-syndicatable-uuid` – the uuid of the content to syndicate
`data-syndicatable-title` – the title of the content to syndicate
`data-syndicatable` – `yes` / `no` / `verify`
`data-syndicatable-target` – the element to insert the syndication flag