### PR TITLE
Update floodlight with temporary tracking tag.

### DIFF
--- a/components/n-ui/tracking/third-party/floodlight.js
+++ b/components/n-ui/tracking/third-party/floodlight.js
@@ -24,6 +24,9 @@ module.exports = function (flags) {
 	if (flags && (flags.get('floodlight') && isAnonymous && spoorId)) {
 
 		const i = new Image();
+		// iNewTest is for a temporary tracking tag to test whether it's the tracking tag that's not working.
+		// Should it be the original tag that was the problem, the current `cat=ft-ne000` should be replaced with `cat=ft-ne003`.
+		const iNewTest = new Image();
 
 		if (isSignUpForm) {
 			i.src = `${host};type=signu107;cat=ft-ne00;dc_lat=;dc_rdid=;tag_for_child_directed_treatment=;ord=1`;
@@ -33,6 +36,7 @@ module.exports = function (flags) {
 			i.src = `${host};type=trans658;cat=ft-ne00;qty=1;u5=${offer};u7=${country};u8=${term};u10=${spoor};dc_lat=;dc_rdid=;tag_for_child_directed_treatment=;`;
 		} else {
 			i.src = `${host};type=homeo886;cat=ft-ne000;u10=${spoor};dc_lat=;dc_rdid=;tag_for_child_directed_treatment=;ord=1;num=1`;
+			iNewTest.src = `${host};type=homeo886;cat=ft-ne003;u10=${spoor};dc_lat=;dc_rdid=;tag_for_child_directed_treatment=;ord=1;num=1`;
 		}
 	}
 }


### PR DESCRIPTION
Both tags will fire simultaneously in order to figure out whether or not the original `cat=ft-ne000` tag is the problem.