### PR TITLE
Check webpack build on test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,9 @@ copy-stylesheet-partial:
 build-css-loader:
 	uglifyjs browser/layout/src/css-loader.js -o browser/layout/partials/css-loader.html
 
+build-webpack:
+	webpack --bail --config build/deploy/webpack.config.js
+
 test-server-coverage: ## test-server-coverage: Run the unit tests with code coverage enabled.
 	istanbul cover node_modules/.bin/_mocha --report=$(if $(CIRCLECI),lcovonly,lcov) server/test/*.test.js server/test/**/*.test.js
 
@@ -77,7 +80,7 @@ a11y: test-build pally-conf
 
 # Note: `run` executes `node demo/app`, which fires up express, then deploys
 # a test static site to s3, then exits, freeing the process to execute `nightwatch a11y`.
-test: developer-note verify pally-conf test-server test-browser test-build test-webpack run nightwatch a11y
+test: developer-note verify pally-conf test-server test-browser test-build test-webpack run nightwatch a11y build-webpack
 
 developer-note:
 ifeq ($(NODE_ENV),) # Not production
@@ -92,7 +95,7 @@ endif
 test-dev: verify test-browser-dev test-webpack
 
 deploy:
-	webpack --bail --config build/deploy/webpack.config.js
+	make build-webpack
 	node ./build/deploy/s3.js
 	$(MAKE) build-css-loader
 	$(MAKE) npm-publish

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,9 @@ endif
 build:
 	webpack --config demo/webpack.config.js --dev
 
+build-production:
+	build-bundle
+
 watch:
 	webpack --config demo/webpack.config.js --dev --watch
 
@@ -88,7 +91,7 @@ a11y: test-build pally-conf
 
 # Note: `run` executes `node demo/app`, which fires up express, then deploys
 # a test static site to s3, then exits, freeing the process to execute `nightwatch a11y`.
-test: developer-note verify pally-conf test-server test-browser test-build test-webpack run nightwatch a11y build-webpack
+test: developer-note verify pally-conf test-server test-browser test-build test-webpack run nightwatch a11y
 
 developer-note:
 ifeq ($(NODE_ENV),) # Not production

--- a/Makefile
+++ b/Makefile
@@ -61,8 +61,16 @@ copy-stylesheet-partial:
 build-css-loader:
 	uglifyjs browser/layout/src/css-loader.js -o browser/layout/partials/css-loader.html
 
-build-webpack:
+build-bundle:
 	webpack --bail --config build/deploy/webpack.config.js
+
+deploy-s3:
+	node ./build/deploy/s3.js
+
+rebuild-user-facing-apps:
+	# only autodeploy all apps in office hours
+	HOUR=$$(date +%H); DAY=$$(date +%u); if [ $$HOUR -ge 8 ] && [ $$HOUR -lt 16 ] && [ $$DAY -ge 0 ] && [ $$DAY -lt 6 ]; then \
+	echo "REBUILDING ALL APPS" && sleep 20 && nht rebuild --all --serves user-page; fi
 
 test-server-coverage: ## test-server-coverage: Run the unit tests with code coverage enabled.
 	istanbul cover node_modules/.bin/_mocha --report=$(if $(CIRCLECI),lcovonly,lcov) server/test/*.test.js server/test/**/*.test.js
@@ -94,11 +102,4 @@ endif
 # Test-dev is only for development environments.
 test-dev: verify test-browser-dev test-webpack
 
-deploy:
-	make build-webpack
-	node ./build/deploy/s3.js
-	$(MAKE) build-css-loader
-	$(MAKE) npm-publish
-	# only autodeploy all apps in office hours
-	HOUR=$$(date +%H); DAY=$$(date +%u); if [ $$HOUR -ge 8 ] && [ $$HOUR -lt 16 ] && [ $$DAY -ge 0 ] && [ $$DAY -lt 6 ]; then \
-	echo "REBUILDING ALL APPS" && sleep 20 && nht rebuild --all --serves user-page; fi
+deploy: build-bundle deploy-s3 build-css-loader npm-publish rebuild-user-facing-apps

--- a/build/deploy/wrapper.js
+++ b/build/deploy/wrapper.js
@@ -1,5 +1,5 @@
 /*global ftNextFireCondition*/
-const nUi = require('../../main');
+const nUi = require('../../browser/js/main');
 
 nUi.bootstrap(window.ftNextUiConfig || {
 	preset: 'discrete',

--- a/components/n-ui/tracking/third-party/chartbeat.js
+++ b/components/n-ui/tracking/third-party/chartbeat.js
@@ -6,7 +6,7 @@ Eventually this will be replaced by FT's in-house "lantern" application, utilisi
 */
 
 import {cookieStore} from 'n-ui-foundations';
-import {loadScript} from '../../../../browser/bootstrap/js/utils';
+import {loadScript} from '../../../../browser/js/utils';
 
 const enableChartbeat = () => {
 	window._sf_async_config = {


### PR DESCRIPTION
A couple of releases happened that failed once merged because it only failed during the `webpack --bail --config build/deploy/webpack.config.js` command which lived within `make deploy`.
`make deploy` only happened on master and therefore it didn't fail on branches. This should ensure we catch these errors on branch builds