### PR TITLE
Allow more og and twittercard metadata

### DIFF
--- a/browser/layout/wrapper.html
+++ b/browser/layout/wrapper.html
@@ -36,25 +36,23 @@
 
 		<meta name="msapplication-TileColor" content="#fff1e0">
 		<meta name="msapplication-TileImage" content="https://www.ft.com/__assets/creatives/brand-ft/icons/v2/mstile-144x144.png">
-		{{#if og}}
-		<meta property="og:title" content="{{ og.title }}">
-		<meta property="og:url" content="{{ og.url }}">
-		<meta property="og:description" content="{{ og.description }}">
-		{{#if og.image}}<meta property="og:image" content="{{ og.image }}">{{/if}}
-		<meta property="og:type" content="article">
+
+		{{#each og}}
+		{{#if this}}
+		<meta property="og:{{@key}}" content="{{this}}">
+		{{/if}}
+		{{/each}}
 		<meta property="og:site_name" content="Financial Times">
+
+		{{#each twitterCard}}
+		{{#if this}}
+		<meta name="twitter:{{@key}}" content="{{this}}">
 		{{/if}}
-		{{#if twitterCard}}
-		<meta property="twitter:card" content="{{ twitterCard.card }}">
-		<meta property="twitter:site" content="@FinancialTimes">
-		<meta property="twitter:title" content="{{ twitterCard.title }}">
-		<meta property="twitter:description" content="{{ twitterCard.description }}">
-		{{#if twitterCard.image}}
-		<meta property="twitter:image" content="{{ twitterCard.image }}">
-		{{else}}
-		<meta property="twitter:image" content="https://www.ft.com/__assets/creatives/brand-ft/icons/v2/favicon-194x194.png">
-		{{/if}}
-		{{/if}}
+		{{/each}}
+		<meta name="twitter:site" content="@FinancialTimes">
+		{{#unless og.image}}
+		<meta name="twitter:image" content="https://www.ft.com/__assets/creatives/brand-ft/icons/v2/favicon-194x194.png">
+		{{/unless}}
 
 		{{#outputBlock 'head'}}{{/outputBlock}}
 


### PR DESCRIPTION
Makes the expected metadata less prescriptive, e.g. https://github.com/Financial-Times/next-video-page/blob/614b6d4296381f2807ef8740d3327dcd7e311c63/server/controllers/video.js#L21-L41

Also, no need to repeat metadata in twitter card if it's already in opengraph - https://dev.twitter.com/cards/getting-started#opengraph