### PR TITLE
Ads optimize lazyload viewportMargin tablet

### DIFF
--- a/components/n-ui/ads/js/oAdsConfig.js
+++ b/components/n-ui/ads/js/oAdsConfig.js
@@ -66,7 +66,7 @@ module.exports = function (flags, appName, adOptions) {
 			case '150':
 				return '150%';
 				break;
-			default://'control'
+			default:
 				return '0%';
 		}
 	}

--- a/components/n-ui/ads/js/oAdsConfig.js
+++ b/components/n-ui/ads/js/oAdsConfig.js
@@ -55,25 +55,29 @@ module.exports = function (flags, appName, adOptions) {
 		return zone.join('/');
 	}
 
+	function setViewpoerMarginBy (variant) {
+		switch (variant) {
+			case '50':
+				return'50%';
+				break;
+			case '100':
+				return '100%';
+				break;
+			case '150':
+				return '150%';
+				break;
+			default://'control'
+				return '0%';
+		}
+	}
+
 	function getViewportMargin () {
 
 		let viewportMargin;
 
 		if (flags.get('adOptimizeLazyLoadSmall') && utils.getScreenSize() < 760 ) {
 			const variant = flags.get('adOptimizeLazyLoadSmall');
-			switch (variant) {
-				case '50':
-					viewportMargin = '50%';
-					break;
-				case '100':
-					viewportMargin = '100%';
-					break;
-				case '150':
-					viewportMargin = '150%';
-					break;
-				default://'control'
-					viewportMargin = '0%';
-			}
+			viewportMargin = setViewpoerMarginBy(variant);
 		} else {
 			viewportMargin = '0%';
 		}

--- a/components/n-ui/ads/js/oAdsConfig.js
+++ b/components/n-ui/ads/js/oAdsConfig.js
@@ -55,7 +55,7 @@ module.exports = function (flags, appName, adOptions) {
 		return zone.join('/');
 	}
 
-	function setViewpoerMarginBy (variant) {
+	function setViewportMarginBy (variant) {
 		switch (variant) {
 			case '50':
 				return'50%';
@@ -71,15 +71,23 @@ module.exports = function (flags, appName, adOptions) {
 		}
 	}
 
+	function isSmallSize () {
+		return utils.getScreenSize() < 760
+	}
+
+	function isMediumSize () {
+		return utils.getScreenSize() >= 760 && utils.getScreenSize() < 980;
+	}
+
 	function getViewportMargin () {
-
-		let viewportMargin;
-
-		if (flags.get('adOptimizeLazyLoadSmall') && utils.getScreenSize() < 760 ) {
+		let viewportMargin = '0%';
+		if (flags.get('adOptimizeLazyLoadSmall') && isSmallSize() ) {
 			const variant = flags.get('adOptimizeLazyLoadSmall');
-			viewportMargin = setViewpoerMarginBy(variant);
-		} else {
-			viewportMargin = '0%';
+			viewportMargin = setViewportMarginBy(variant);
+		}
+		if (flags.get('adOptimizeLazyLoadMedium') && isMediumSize() ) {
+			const variant = flags.get('adOptimizeLazyLoadMedium');
+			viewportMargin = setViewportMarginBy(variant);
 		}
 		return viewportMargin;
 	}

--- a/components/n-ui/ads/test/oAdsConfig.spec.js
+++ b/components/n-ui/ads/test/oAdsConfig.spec.js
@@ -216,6 +216,24 @@ describe('Config', () => {
 			expect(config.lazyLoad.viewportMargin).to.equal('0%');
 		});
 
+		it('Should pass 0% when screen size is less than 760px and adOptimizeLazyLoadMedium flag is defined', () => {
+			sandbox.stub(utils, 'getScreenSize', () => { return 759; });
+			const flags = { get: (flagName) => {
+				switch (flagName) {
+					case 'adOptimizeLazyLoadSmall':
+					return false;
+					break;
+					case 'adOptimizeLazyLoadMedium':
+					return '50';
+					break;
+					default:
+					return true;
+				}
+			}};
+			const config = oAdsConfig(flags, 'article');
+			expect(config.lazyLoad.viewportMargin).to.equal('0%');
+		});
+
 		it('Should pass 0% when screen size is more than 760px, less than 980px and adOptimizeLazyLoadMedium flag is undefined', () => {
 			sandbox.stub(utils, 'getScreenSize', () => { return 800; });
 			const flags = { get: (flagName) => {

--- a/components/n-ui/ads/test/oAdsConfig.spec.js
+++ b/components/n-ui/ads/test/oAdsConfig.spec.js
@@ -110,12 +110,16 @@ describe('Config', () => {
 
 	describe('lazyLoad viewportMargin', () => {
 
+	// tests for adOptimizeLazyLoadSmall flag
 		it('Should pass 0% when screen size is wider than 760px and adOptimizeLazyLoadSmall flag is defined', () => {
 			sandbox.stub(utils, 'getScreenSize', () => { return 760; });
 			const flags = { get: (flagName) => {
 				switch (flagName) {
 					case 'adOptimizeLazyLoadSmall':
 					return '50';
+					break;
+					case 'adOptimizeLazyLoadMedium':
+					return false;
 					break;
 					default:
 					return true;
@@ -131,6 +135,9 @@ describe('Config', () => {
 				switch (flagName) {
 					case 'adOptimizeLazyLoadSmall':
 					return undefined;
+					break;
+					case 'adOptimizeLazyLoadMedium':
+					return false;
 					break;
 					default:
 					return true;
@@ -158,6 +165,9 @@ describe('Config', () => {
 							case 'adOptimizeLazyLoadSmall':
 							return margin;
 							break;
+							case 'adOptimizeLazyLoadMedium':
+							return false;
+							break;
 							default:
 							return true;
 						}
@@ -172,6 +182,96 @@ describe('Config', () => {
 				const flags = { get: (flagName) => {
 					switch (flagName) {
 						case 'adOptimizeLazyLoadSmall':
+						return 'control';
+						break;
+						case 'adOptimizeLazyLoadMedium':
+						return false;
+						break;
+						default:
+						return true;
+					}
+				}};
+				const config = oAdsConfig(flags, 'article');
+				expect(config.lazyLoad.viewportMargin).to.equal('0%');
+			});
+
+		});
+
+	// tests for adOptimizeLazyLoadMedium flag
+		it('Should pass 0% when screen size is wider than 980px and adOptimizeLazyLoadMedium flag is defined', () => {
+			sandbox.stub(utils, 'getScreenSize', () => { return 980; });
+			const flags = { get: (flagName) => {
+				switch (flagName) {
+					case 'adOptimizeLazyLoadSmall':
+					return false;
+					break;
+					case 'adOptimizeLazyLoadMedium':
+					return '50';
+					break;
+					default:
+					return true;
+				}
+			}};
+			const config = oAdsConfig(flags, 'article');
+			expect(config.lazyLoad.viewportMargin).to.equal('0%');
+		});
+
+		it('Should pass 0% when screen size is more than 760px, less than 980px and adOptimizeLazyLoadMedium flag is undefined', () => {
+			sandbox.stub(utils, 'getScreenSize', () => { return 800; });
+			const flags = { get: (flagName) => {
+				switch (flagName) {
+					case 'adOptimizeLazyLoadSmall':
+					return false;
+					break;
+					case 'adOptimizeLazyLoadMedium':
+					return undefined;
+					break;
+					default:
+					return true;
+				}
+			}};
+			const config = oAdsConfig(flags, 'article');
+			expect(config.lazyLoad.viewportMargin).to.equal('0%');
+		});
+
+		context('when screen size is more than 760px, less than 980px and adOptimizeLazyLoadMedium flag is defined', () => {
+
+			beforeEach(() => {
+				sandbox.stub(utils, 'getScreenSize', () => { return 800; });
+			});
+
+			afterEach(() => {
+				sandbox.restore();
+			});
+
+			['50', '100', '150'].forEach( margin => {
+
+				it(`Should pass ${margin}% when the flag\'s value is ${margin}`, () => {
+					const flags = { get: (flagName) => {
+						switch (flagName) {
+							case 'adOptimizeLazyLoadSmall':
+							return false;
+							break;
+							case 'adOptimizeLazyLoadMedium':
+							return margin;
+							break;
+							default:
+							return true;
+						}
+					}};
+					const config = oAdsConfig(flags, 'article');
+					expect(config.lazyLoad.viewportMargin).to.equal(`${margin}%`);
+				});
+
+			});
+
+			it('Should pass 0% when the flag\'s value is control', () => {
+				const flags = { get: (flagName) => {
+					switch (flagName) {
+						case 'adOptimizeLazyLoadSmall':
+						return false;
+						break;
+						case 'adOptimizeLazyLoadMedium':
 						return 'control';
 						break;
 						default:

--- a/components/n-ui/ads/test/oAdsConfig.spec.js
+++ b/components/n-ui/ads/test/oAdsConfig.spec.js
@@ -178,23 +178,6 @@ describe('Config', () => {
 
 			});
 
-			it('Should pass 0% when the flag\'s value is control', () => {
-				const flags = { get: (flagName) => {
-					switch (flagName) {
-						case 'adOptimizeLazyLoadSmall':
-						return 'control';
-						break;
-						case 'adOptimizeLazyLoadMedium':
-						return false;
-						break;
-						default:
-						return true;
-					}
-				}};
-				const config = oAdsConfig(flags, 'article');
-				expect(config.lazyLoad.viewportMargin).to.equal('0%');
-			});
-
 		});
 
 	// tests for adOptimizeLazyLoadMedium flag
@@ -281,23 +264,6 @@ describe('Config', () => {
 					expect(config.lazyLoad.viewportMargin).to.equal(`${margin}%`);
 				});
 
-			});
-
-			it('Should pass 0% when the flag\'s value is control', () => {
-				const flags = { get: (flagName) => {
-					switch (flagName) {
-						case 'adOptimizeLazyLoadSmall':
-						return false;
-						break;
-						case 'adOptimizeLazyLoadMedium':
-						return 'control';
-						break;
-						default:
-						return true;
-					}
-				}};
-				const config = oAdsConfig(flags, 'article');
-				expect(config.lazyLoad.viewportMargin).to.equal('0%');
 			});
 
 		});


### PR DESCRIPTION
See this ticket below;
https://trello.com/c/zGJOxLIq/142-optimise-ad-lazy-load-trigger-on-tablet

and I have deleted a test `Should pass 0% when the flag\'s value is control` from mobile(Small size) as well because `flags.get('adOptimizeLazyLoadSmall')` just returns false when the variant is control.