### PR TITLE
Make edition switcher URL configurable.

### DIFF
--- a/components/n-ui/header/partials/drawer/template.html
+++ b/components/n-ui/header/partials/drawer/template.html
@@ -57,7 +57,7 @@
 				{{#if @root.editions}}
 					{{#each @root.editions.others}}
 						<li class="o-header__drawer-menu-item" data-trackable="edition-switcher">
-							<a class="o-header__drawer-menu-link" href="/?edition={{id}}" data-trackable="{{id}}">Switch to {{name}} Edition</a>
+							<a class="o-header__drawer-menu-link" href="{{url}}?edition={{id}}" data-trackable="{{id}}">Switch to {{name}} Edition</a>
 						</li>
 					{{/each}}
 				{{/if}}

--- a/server/models/navigation/editionsModel.js
+++ b/server/models/navigation/editionsModel.js
@@ -1,11 +1,13 @@
 const availableEditions = [
 	{
 		id: 'uk',
-		name: 'UK'
+		name: 'UK',
+		url: '/'
 	},
 	{
 		id: 'international',
-		name: 'International'
+		name: 'International',
+		url: '/'
 	}
 ];
 

--- a/server/test/navigation/editions.test.js
+++ b/server/test/navigation/editions.test.js
@@ -14,11 +14,13 @@ describe('Editions', () => {
 		let expected = [
 			{
 				id: 'uk',
-				name: 'UK'
+				name: 'UK',
+				url: '/'
 			},
 			{
 				id: 'international',
-				name: 'International'
+				name: 'International',
+				url: '/'
 			}
 		];
 


### PR DESCRIPTION
Useful for pages like epaper which should have an edition switcher on page, so that switching editions doesn't take you back to the front page.