### PR TITLE
properly resolve a bower.json main array

### DIFF
--- a/build/webpack.common.config.js
+++ b/build/webpack.common.config.js
@@ -8,7 +8,7 @@ If something is required for both, please add it here.
 const ExtractTextPlugin = require('extract-text-webpack-plugin');
 const autoprefixer = require('autoprefixer');
 const path = require('path');
-
+const BowerResolvePlugin = require("bower-resolve-webpack-plugin");
 
 const extractOptions = [{
 		loader: 'css-loader',
@@ -50,6 +50,12 @@ module.exports = {
 	devtool: 'source-map',
 
 	resolve: {
+
+		plugins: [
+			// This will handle a bower.json's `main` property being an array.
+			new BowerResolvePlugin()
+		],
+
 		// In which folders the resolver look for modules relative paths are
 		// looked up in every parent folder (like node_modules) absolute
 		// paths are looked up directly the order is respected
@@ -67,9 +73,7 @@ module.exports = {
 		// These files are tried when trying to resolve a directory
 		mainFiles: [
 			'index',
-			'main',
-			'src/main-client', /* HACK: this is because of n-image's entrypoint not being main.js or index.js */
-			'dist/main' /* HACK: this is because of n-storylines entrypoint not being main.js or index.js */
+			'main'
 		],
 
 		// These fields in the description files offer aliasing in this package

--- a/build/webpack.common.config.js
+++ b/build/webpack.common.config.js
@@ -8,7 +8,7 @@ If something is required for both, please add it here.
 const ExtractTextPlugin = require('extract-text-webpack-plugin');
 const autoprefixer = require('autoprefixer');
 const path = require('path');
-const BowerResolvePlugin = require("bower-resolve-webpack-plugin");
+const BowerResolvePlugin = require('bower-resolve-webpack-plugin');
 
 const extractOptions = [{
 		loader: 'css-loader',

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "babel-plugin-transform-runtime": "^6.12.0",
     "babel-preset-es2015": "^6.14.0",
     "babel-preset-react": "^6.11.1",
+    "bower-resolve-webpack-plugin": "^1.0.3",
     "chokidar": "^1.6.1",
     "classnames": "^2.2.5",
     "clone": "^1.0.2",


### PR DESCRIPTION
This plugin ensures a `bower.json`'s `main` property can be an array and it will resolve to the JS entry point specified.