### PR TITLE
Fix watching stylesheets and outut correct name

### DIFF
--- a/server/lib/asset-manager/stylesheet-manager.js
+++ b/server/lib/asset-manager/stylesheet-manager.js
@@ -73,13 +73,16 @@ module.exports = {
 			chokidar.watch(paths)
 				.on('change', (path) => {
 					readFile(path, 'utf-8').then((content) => {
-						const name = path.match(/\.css$/)[1];
+						let name = path.split('/');
+						name = name[name.length - 1].slice(0, -4);
+						concatenatedStylesCache = {};
 						stylesheets[name] = content;
 						logger.info(`Reloaded head CSS: ${name}`);
 					});
 				})
 				.on('unlink', (path) => {
-					const name = path.match(/\.css$/)[1];
+					let name = path.split('/');
+					name = name[name.length - 1].slice(0, -4);
 					delete stylesheets[name];
 					logger.info(`Deleted head CSS: ${name}`);
 					logger.warn('Please note you will need to restart app if you add new head CSS files');


### PR DESCRIPTION
- Clear the cached stylesheets when using `make watch` so changes to
  inline styles are reflected.

- Also fix the name so the correct name is logged to the terminal rather
  than `undefined`