### PR TITLE
include raw-loader for comments

### DIFF
--- a/build/app/webpack.app.common.js
+++ b/build/app/webpack.app.common.js
@@ -38,6 +38,10 @@ module.exports = webpackMerge(commonConfig, {
 				test: /\.html$/,
 				loader: 'handlebars-loader',
 				options: handlebarsConfig()
+			},
+			{
+				test: /\.txt$/,
+				loader: 'raw-loader'
 			}
 		]
 	}

--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "preact-compat": "^3.11.0",
     "promise-rat-race": "^1.5.1",
     "proptypes": "^0.14.3",
+    "raw-loader": "^0.5.1",
     "sass-loader": "^6.0.5",
     "semver": "^5.3.0",
     "shellpromise": "^1.4.0",


### PR DESCRIPTION
Includes raw loader and reads in txt files, specifically for comments-ui because webpack and loaders, and Jake totally gets it.

Directly related to https://github.com/Financial-Times/origami-build-tools/pull/473