### PR TITLE
removed n-marketing from bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -32,7 +32,6 @@
     "n-ui-foundations": "^2.2.1",
     "o-expander": "^4.2.2",
     "next-session-client": "^2.3.1",
-    "n-counter-ad-blocking": "^3.1.0",
-    "n-marketing": "^1.0.0"
+    "n-counter-ad-blocking": "^3.1.0"
   }
 }


### PR DESCRIPTION
n-marketing doesn't need to be listed as a bower dependency in `n-ui` as it's installed directly in `next-front-page` and `next-stream-page` 