### PR TITLE
remove some superfluous tests

### DIFF
--- a/server/test/bad-assets.test.js
+++ b/server/test/bad-assets.test.js
@@ -28,11 +28,11 @@ describe('built asset expectations', () => {
 		return shellpromise(`rm -rf ${appPath}/public/main.js`, { verbose: true })
 		.then(() => {
 			return appStart()
-			.then(() => {
-				throw new Error('app should not have successfully started');
-			}, err => {
-				expect(err.toString()).to.contain('main.js');
-			});
+				.then(() => {
+					throw new Error('app should not have successfully started');
+				}, err => {
+					expect(err.toString()).to.contain('main.js');
+				});
 		});
 
 	});
@@ -42,24 +42,4 @@ describe('built asset expectations', () => {
 		return shellpromise(`touch ${appPath}/public/about.json`)
 			.then(appStart);
 	});
-
-	it('should start if public directory in gitignore', () => {
-		createGitignore('/public/');
-		return shellpromise(`touch ${appPath}/public/about.json`)
-			.then(appStart);
-	});
-
-	it('should start if wildcarded public directory in gitignore', () => {
-		createGitignore('/public/*');
-		return shellpromise(`touch ${appPath}/public/about.json`)
-			.then(appStart);
-	});
-
-	it('should start if no mention of public in gitignore', () => {
-		createGitignore('cat', 'dog');
-		return shellpromise(`touch ${appPath}/public/about.json`)
-			.then(appStart);
-	});
-
-
 });


### PR DESCRIPTION
@leggsimon These were only needed when they were part of n-express i.e. had to cover apps that didn't have client side assets