### PR TITLE
allow different product name

### DIFF
--- a/components/n-ui/tracking/ft/index.js
+++ b/components/n-ui/tracking/ft/index.js
@@ -41,7 +41,7 @@ const oTrackingWrapper = {
 			}
 
 			const context = {
-				product: 'next',
+				product: appInfo && appInfo.product || 'next',
 				app: appInfo && appInfo.name,
 				appVersion: appInfo && appInfo.version
 			};


### PR DESCRIPTION
@wheresrhys @leggsimon 
KAT and Syndication use n-ui but need a way of changing the product name, hardcoded until now.

