### PR TITLE
remove adInitEarlierNui

### DIFF
--- a/browser/js/component-initializer.js
+++ b/browser/js/component-initializer.js
@@ -100,13 +100,6 @@ export class ComponentInitializer {
 				this.initializedFeatures.date = true;
 			}
 
-			if (flags.get('adInitEarlierNui')){
-				if (config.features.ads && !this.initializedFeatures.ads) {
-					ads.init(flags, appInfo, config.features.ads);
-					this.initializedFeatures.ads = true;
-				}
-			}
-
 			if (config.features.lazyLoadImages && !this.initializedFeatures.lazyLoadImages) {
 				lazyLoadImages();
 				this.initializedFeatures.lazyLoadImages = true;
@@ -136,11 +129,9 @@ export class ComponentInitializer {
 				.then(cb)
 				.then(() => {
 					// TODO - lazy load this
-					if (!flags.get('adInitEarlierNui')){
-						if (config.features.ads && !this.initializedFeatures.ads) {
-							ads.init(flags, appInfo, config.features.ads);
-							this.initializedFeatures.ads = true;
-						}
+					if (config.features.ads && !this.initializedFeatures.ads) {
+						ads.init(flags, appInfo, config.features.ads);
+						this.initializedFeatures.ads = true;
 					}
 
 					if (!this.initializedFeatures.lazyTracking) {


### PR DESCRIPTION
We didn't get a big difference with viewabilty when ads are initialised earlier. We are going to take the flag off and go back before we added the code.
 
🐿 v2.5.13