### PR TITLE
remove adInitEalierNui flag

### DIFF
--- a/browser/js/component-initializer.js
+++ b/browser/js/component-initializer.js
@@ -100,11 +100,9 @@ export class ComponentInitializer {
 				this.initializedFeatures.date = true;
 			}
 
-			if (flags.get('adInitEarlierNui')){
-				if (config.features.ads && !this.initializedFeatures.ads) {
-					ads.init(flags, appInfo, config.features.ads);
-					this.initializedFeatures.ads = true;
-				}
+			if (config.features.ads && !this.initializedFeatures.ads) {
+				ads.init(flags, appInfo, config.features.ads);
+				this.initializedFeatures.ads = true;
 			}
 
 			if (config.features.lazyLoadImages && !this.initializedFeatures.lazyLoadImages) {
@@ -136,12 +134,6 @@ export class ComponentInitializer {
 				.then(cb)
 				.then(() => {
 					// TODO - lazy load this
-					if (!flags.get('adInitEarlierNui')){
-						if (config.features.ads && !this.initializedFeatures.ads) {
-							ads.init(flags, appInfo, config.features.ads);
-							this.initializedFeatures.ads = true;
-						}
-					}
 
 					if (!this.initializedFeatures.lazyTracking) {
 						tracking.lazyInit(flags);


### PR DESCRIPTION
We are going to roll out the feature which ads are initialised earlier. This PR is the correct one!

This PR is the opposite way of the PR below. (I misunderstood the situation and made the PR)
https://github.com/Financial-Times/n-ui/pull/1055
 
🐿 v2.5.13