### PR TITLE
add app-argument URL to smart banner tag

### DIFF
--- a/browser/layout/wrapper.html
+++ b/browser/layout/wrapper.html
@@ -34,7 +34,7 @@
 		<link rel="apple-touch-icon" sizes="180x180" href="https://www.ft.com/__assets/creatives/brand-ft/icons/v2/apple-touch-icon-180x180.png">
 
 		{{#unless __disableIosSmartBanner}}
-		<meta name="apple-itunes-app" content="app-id=1200842933, affiliate-data=ct=smart-banner&pt=246269">
+		<meta name="apple-itunes-app" content="app-id=1200842933, affiliate-data=ct=smart-banner&pt=246269, app-arguments={{#if canonicalUrl}}{{canonicalUrl}}{{else}}https://www.ft.com{{/if}}">
 		{{/unless}}
 		{{#if __disableAndroidBanner}}
 		<script>


### PR DESCRIPTION
without providing this, the app gets no context when it's opened, and we'd like to keep the user on the same page if possible. uses `canonicalUrl` if available and https://www.ft.com if not. `canonicalUrl` is available on article and stream page, which is sufficient for us.
 🐿 v2.5.16