### PR TITLE
make n-ui work again when flags disabled

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -67,9 +67,9 @@ module.exports = options => {
 
 	// set whether or not to disable the app install banner.
 	app.use(function (req, res, next) {
-		app.locals.__disableAndroidBanner = (!res.locals.flags.subscriberCohort || res.locals.flags.disableAndroidSmartBanner);
-		app.locals.__disableIosSmartBanner = (!res.locals.flags.subscriberCohort || res.locals.flags.disableIosSmartBanner);
-		app.locals.__enableDesktopAppBanner = res.locals.flags.subscriberCohort && res.locals.flags.onboardingMessaging === 'appPromotingBanner';
+		app.locals.__disableAndroidBanner = res.locals.flags && (!res.locals.flags.subscriberCohort || res.locals.flags.disableAndroidSmartBanner);
+		app.locals.__disableIosSmartBanner = res.locals.flags && (!res.locals.flags.subscriberCohort || res.locals.flags.disableIosSmartBanner);
+		app.locals.__enableDesktopAppBanner = res.locals.flags && res.locals.flags.subscriberCohort && res.locals.flags.onboardingMessaging === 'appPromotingBanner';
 
 		next();
 	});


### PR DESCRIPTION
 ```js
app = express({ ... withFlags: false ... }) 
```
throws right now because `withFlags: false` means no `res.locals.flags`