### PR TITLE
Remove role presentation from the header

### DIFF
--- a/components/n-ui/header/template.html
+++ b/components/n-ui/header/template.html
@@ -37,7 +37,7 @@
 </header>
 
 {{#unless nUi.header.disableSticky}}
-	<header class="o-header o-header--simple o-header--sticky o--if-js" aria-hidden="true" role="presentation" data-o-header--sticky>
+	<header class="o-header o-header--simple o-header--sticky o--if-js" aria-hidden="true" data-o-header--sticky>
 		{{> n-ui/header/partials/header/sticky}}
 
 		{{> n-ui/header/partials/header/search context="sticky"}}


### PR DESCRIPTION
This will soon cause errors for everyone when Pa11y runs. The
`role="presentation"` attribute was only ever really added to make sure
we were hiding it from keyboard focus and from the accessibility api.
However we also use `aria-hidden="true"` on the parent and
`tabindex="-1"` on all the children to achieve this.

 🐿2.5.10