### PR TITLE
Use app-argument for the Apple smart banner meta tag

### DIFF
--- a/browser/layout/wrapper.html
+++ b/browser/layout/wrapper.html
@@ -34,7 +34,7 @@
 		<link rel="apple-touch-icon" sizes="180x180" href="https://www.ft.com/__assets/creatives/brand-ft/icons/v2/apple-touch-icon-180x180.png">
 
 		{{#unless __disableIosSmartBanner}}
-		<meta name="apple-itunes-app" content="app-id=1200842933, affiliate-data=ct=smart-banner&pt=246269, app-arguments={{#if canonicalUrl}}{{canonicalUrl}}{{else}}https://www.ft.com{{/if}}">
+		<meta name="apple-itunes-app" content="app-id=1200842933, affiliate-data=ct=smart-banner&pt=246269, app-argument={{#if canonicalUrl}}{{canonicalUrl}}{{else}}https://www.ft.com{{/if}}">
 		{{/unless}}
 		{{#if __disableAndroidBanner}}
 		<script>


### PR DESCRIPTION
https://developer.apple.com/library/content/documentation/AppleApplications/Reference/SafariWebContent/PromotingAppswithAppBanners/PromotingAppswithAppBanners.html suggests it's `app-argument` not `app-arguments` 😛 

 🐿 v2.5.16