### PR TITLE
add nui build-sass

### DIFF
--- a/build/app/cli.js
+++ b/build/app/cli.js
@@ -74,8 +74,8 @@ program
 			}
 		}
 
-		concurrentCommands = concurrentCommands.length 
-			? concurrentCommands 
+		concurrentCommands = concurrentCommands.length
+			? concurrentCommands
 			: Object.keys(commands).map(c => command[c]);
 
 		shellpipe(`concurrently ${concurrentCommands.join(' ')}`)
@@ -87,7 +87,7 @@ program
 				const buildTime = Date.now() - buildStartTime;
 
 				// Don't send metrics from CircleCI builds
-				if (!process.env.CIRCLECI) {
+				if (!process.env.CIRCLECI && !options['js-only'] && !options['sass-only']) {
 					sendBuildMetrics(appPackageJson.name, buildTime);
 				}
 

--- a/build/app/cli.js
+++ b/build/app/cli.js
@@ -76,7 +76,7 @@ program
 
 		concurrentCommands = concurrentCommands.length
 			? concurrentCommands
-			: Object.keys(commands).map(c => command[c]);
+			: Object.keys(commands).map(c => commands[c]);
 
 		shellpipe(`concurrently ${concurrentCommands.join(' ')}`)
 			.then(() => options.production && assetHashes())

--- a/build/app/cli.js
+++ b/build/app/cli.js
@@ -74,7 +74,9 @@ program
 			}
 		}
 
-		concurrentCommands = concurrentCommands.length ? concurrentCommands : Object.values(commands);
+		concurrentCommands = concurrentCommands.length 
+			? concurrentCommands 
+			: Object.keys(commands).map(c => command[c]);
 
 		shellpipe(`concurrently ${concurrentCommands.join(' ')}`)
 			.then(() => options.production && assetHashes())

--- a/build/app/cli.js
+++ b/build/app/cli.js
@@ -60,7 +60,7 @@ program
 
 		devAdvice();
 		const buildStartTime = Date.now();
-		let concurrentComands = [];
+		let concurrentCommands = [];
 
 		const script = './node_modules/@financial-times/n-ui/scripts/build-sass.sh';
 		const commands = {
@@ -70,13 +70,13 @@ program
 
 		for(let key in commands) {
 			if(!!options[key]) {
-				concurrentComands.push(commands[key]);
+				concurrentCommands.push(commands[key]);
 			}
 		}
 
-		concurrentComands = concurrentComands.length ? concurrentComands : Object.values(commands);
+		concurrentCommands = concurrentCommands.length ? concurrentCommands : Object.values(commands);
 
-		shellpipe(`concurrently ${concurrentComands.join(' ')}`)
+		shellpipe(`concurrently ${concurrentCommands.join(' ')}`)
 			.then(() => options.production && assetHashes())
 			.then(aboutJson)
 			.then(grabNUiAssets)


### PR DESCRIPTION
Just an idea: could we have a `nui build-sass` command? It would be great to have a way to build css only locally. Doing it concurrently with webpack hangs for a lot of us.

Or a `--sass-only` flag on `nui build`?