### PR TITLE
Added 'nui compress' command

### DIFF
--- a/build/app/cli.js
+++ b/build/app/cli.js
@@ -7,6 +7,7 @@ const shellpipe = require('./shellpipe');
 const grabNUiAssets = require('./grab-n-ui-assets');
 const assetHashes = require('../lib/generate-asset-hashes');
 const sendBuildMetrics = require('../lib/send-build-metrics');
+const generateCompressedAssets = require('../lib/generate-compressed-assets');
 
 const exit = err => {
 	logger.error(err);
@@ -113,6 +114,18 @@ program
 
 		grabNUiAssets()
 			.then(() => shellpipe(`concurrently "webpack --watch --config ${webpackConfPath}" ${cssBuildWatchCommands}`))
+			.catch(exit);
+	});
+
+program
+	.command('compress')
+	.description('Generate compressed copies of any assets (css, js, map, json etc) in the /public directory.')
+	.action(() => {
+		const assetPath = `${process.cwd()}/public/`;
+		generateCompressedAssets(assetPath)
+			.then(() => {
+				exit(`✓ Successfully generated compressed copies of all assets in ${assetPath}`);
+			})
 			.catch(exit);
 	});
 

--- a/build/lib/generate-compressed-assets.js
+++ b/build/lib/generate-compressed-assets.js
@@ -1,0 +1,35 @@
+/* eslint-disable no-console */
+const fs = require('fs');
+const path = require('path');
+const denodeify = require('denodeify');
+const compress = denodeify(require('iltorb').compress);
+const readFile = denodeify(fs.readFile);
+const writeFile = denodeify(fs.writeFile);
+
+const read = dir => fs.readdirSync(dir).reduce((files, name) => {
+	if (fs.statSync(path.join(dir, name)).isDirectory()) {
+		return files.concat(read(path.join(dir, name)));
+	} else {
+		return files.concat({
+			uncompressed: {dir, name},
+			compressed: {dir: `${dir}/compressed/`, name: `${name}.br`}
+		});
+	}
+}, []);
+
+module.exports = assetPath => {
+	const files = read(assetPath);
+	return Promise.all(files.map(file => {
+		if (!fs.existsSync(file.compressed.dir)) {
+			fs.mkdirSync(file.compressed.dir);
+		}
+		return readFile(path.join(file.uncompressed.dir,file.uncompressed.name))
+			.then(buffer => compress(buffer,{quality: 11}))
+			.then(contents => {
+				return writeFile(path.join(file.compressed.dir,file.compressed.name), contents)
+					.then(() => path.join(file.compressed.dir,file.compressed.name))
+					.catch(error => console.error(error));
+			});
+		}
+	)).catch(error => console.error(error));
+};


### PR DESCRIPTION
# TODO: Move this PR to [n-heroku-tools](https://github.com/Financial-Times/n-heroku-tools)


Added `nui compress` command: 

> Generate compressed copies of any assets (css, js, map, json etc) in the `/public` directory.

This is not currently used by anything, but I plan to wire it up in the `nui deploy` pipeline.

![image](https://user-images.githubusercontent.com/224547/31277199-b40eb868-aa97-11e7-82d7-c762d01a9e5a.png)
For the `next-frontpage` app, its production build of `/public` assets is compressed from 1.9mb to 291kb. 

![image](https://user-images.githubusercontent.com/224547/31277243-f8dd0bd4-aa97-11e7-9f87-78ebb9bb5647.png)
The two core `/public/n-ui` files are also compressed.

![image](https://user-images.githubusercontent.com/224547/31277272-17cd29b6-aa98-11e7-8832-8fb92b500e85.png)
Here's how it looks when running `nui compress` in `next-front-page`

![image](https://user-images.githubusercontent.com/224547/31277327-4fd59906-aa98-11e7-99c4-702e61c1c675.png)
The compressed files are saved to their own `./compressed` directory.