### PR TITLE
make cors errors more informative

### DIFF
--- a/browser/bundles/o-errors.js
+++ b/browser/bundles/o-errors.js
@@ -20,14 +20,31 @@ oErrors.init({
 	errorBuffer: window.errorBuffer || []
 });
 
-// turn on more detailed error reporting of ajax calls
-if (window.FT.flags.clientAjaxErrorReporting) {
+
+(function () {
+	// Cors errors are so uninformative. This forces them to be a bit more informative
 	const realFetch = window.fetch;
 	window.fetch = function (url, opts) {
 		return realFetch.call(this, url, opts)
 			.catch(function (err) {
-				oErrors.log(url + (opts ? JSON.stringify(opts) : '' ) + err);
+				if (err.message === 'Failed to fetch') {
+					throw new TypeError(`Cors error when calling ${url}`);
+				}
 				throw err;
 			});
 	};
+}());
+
+// turn on more detailed error reporting of ajax calls
+if (window.FT.flags.clientAjaxErrorReporting) {
+	(function () {
+		const realFetch = window.fetch;
+		window.fetch = function (url, opts) {
+			return realFetch.call(this, url, opts)
+				.catch(function (err) {
+					oErrors.log(url + (opts ? JSON.stringify(opts) : '' ) + err);
+					throw err;
+				});
+		};
+	}());
 }

--- a/browser/bundles/o-errors.js
+++ b/browser/bundles/o-errors.js
@@ -28,7 +28,7 @@ oErrors.init({
 		return realFetch.call(this, url, opts)
 			.catch(function (err) {
 				if (err.message === 'Failed to fetch') {
-					throw new TypeError(`Cors error when calling ${url}`);
+					throw new TypeError(`Cors error when fetching ${url}`);
 				}
 				throw err;
 			});


### PR DESCRIPTION
Reading up here https://gauntface.com/blog/2015/02/11/fetch-is-the-new-xhr, this change should help triage the river of cryptic errors here https://sentry.io/nextftcom/ft-next-frontend/issues/316535232/events/latest/