### PR TITLE
Check intersecting properly before firing scroll depth

### DIFF
--- a/components/n-ui/tracking/ft/events/scroll-depth-components.js
+++ b/components/n-ui/tracking/ft/events/scroll-depth-components.js
@@ -5,13 +5,15 @@ const track = (componentId, componentPos) =>
 
 const intersectionCallback = (observer, changes) =>
 	changes.forEach(change => {
-		const component = change.target;
-		const componentId = component.id || component.getAttribute('data-trackable');
-		// get the component's position
-		const componentPos = [...document.querySelectorAll('.js-track-scroll-event')]
-			.findIndex(component => (component.id || component.getAttribute('data-trackable')) === componentId);
-		track(componentId, componentPos + 1);
-		observer.unobserve(component);
+		if(change.isIntersecting || change.intersectionRatio > 0) {
+			const component = change.target;
+			const componentId = component.id || component.getAttribute('data-trackable');
+			// get the component's position
+			const componentPos = [...document.querySelectorAll('.js-track-scroll-event')]
+				.findIndex(component => (component.id || component.getAttribute('data-trackable')) === componentId);
+			track(componentId, componentPos + 1);
+			observer.unobserve(component);
+		}
 	});
 
 const init = () => {

--- a/components/n-ui/tracking/ft/events/scroll-depth.js
+++ b/components/n-ui/tracking/ft/events/scroll-depth.js
@@ -26,12 +26,14 @@ const scrollDepth = {
 
 		const intersectionCallback = (observer, changes) => {
 			changes.forEach(change => {
-				const scrollDepthMarkerEl = change.target;
-				fireBeacon(contextSource, scrollDepthMarkerEl.getAttribute('data-percentage'));
-				if (scrollDepthMarkerEl.parentNode) {
-					scrollDepthMarkerEl.parentNode.removeChild(scrollDepthMarkerEl);
+				if(change.isIntersecting || change.intersectionRatio > 0) {
+					const scrollDepthMarkerEl = change.target;
+					fireBeacon(contextSource, scrollDepthMarkerEl.getAttribute('data-percentage'));
+					if (scrollDepthMarkerEl.parentNode) {
+						scrollDepthMarkerEl.parentNode.removeChild(scrollDepthMarkerEl);
+					}
+					observer.unobserve(scrollDepthMarkerEl);
 				}
-				observer.unobserve(scrollDepthMarkerEl);
 			});
 		};
 


### PR DESCRIPTION
For some reason this is no longer working with the new article grid. 

Haven't debugged properly, but from what I can see as soon as they get added a change is triggered without actually intersecting. We use this check in other places that we use intersection observer so copying that.