### PR TITLE
Use latest (v3) brand icons

### DIFF
--- a/browser/layout/wrapper.html
+++ b/browser/layout/wrapper.html
@@ -49,7 +49,7 @@
 		<link rel="manifest" href="/assets/manifest/manifest-v6.json">
 
 		<meta name="msapplication-TileColor" content="#fff1e0">
-		<meta name="msapplication-TileImage" content="https://www.ft.com/__assets/creatives/brand-ft/icons/v2/mstile-144x144.png">
+		<meta name="msapplication-TileImage" content="https://www.ft.com/__assets/creatives/brand-ft/icons/v3/mstile-144x144.png">
 
 		{{#each openGraph}}
 		{{#each this}}
@@ -79,8 +79,8 @@
 		{{/each}}
 		<meta name="twitter:site" content="@FinancialTimes">
 		{{#unless openGraph.og.image}}
-		<meta name="og:image" content="https://www.ft.com/__assets/creatives/brand-ft/icons/v2/open-graph.png">
-		<meta name="twitter:image" content="https://www.ft.com/__assets/creatives/brand-ft/icons/v2/open-graph.png">
+		<meta name="og:image" content="https://www.ft.com/__assets/creatives/brand-ft/icons/v3/open-graph.png">
+		<meta name="twitter:image" content="https://www.ft.com/__assets/creatives/brand-ft/icons/v3/open-graph.png">
 		{{/unless}}
 
 		{{#outputBlock 'head'}}{{/outputBlock}}


### PR DESCRIPTION
Updates opengraph images and MS tile image to use v3 assets.

Brings inline with the logos in origami: http://registry.origami.ft.com/components/logo-images