### PR TITLE
add apple touch bar icon

### DIFF
--- a/browser/layout/wrapper.html
+++ b/browser/layout/wrapper.html
@@ -36,6 +36,9 @@
 		<link rel="icon" type="image/png" href="https://www.ft.com/__origami/service/image/v2/images/raw/ftlogo-v1%3Abrand-ft-logo-square-coloured?source=update-logos&width=32&height=32&format=png" sizes="32x32">
 		<link rel="icon" type="image/png" href="https://www.ft.com/__origami/service/image/v2/images/raw/ftlogo-v1%3Abrand-ft-logo-square-coloured?source=update-logos&width=194&height=194&format=png" sizes="194x194">
 		<link rel="apple-touch-icon" sizes="180x180" href="https://www.ft.com/__origami/service/image/v2/images/raw/ftlogo-v1%3Abrand-ft-logo-square-coloured?source=update-logos&width=180&height=180&format=png">
+		{{#if @root.flags.appleTouchBarIcon}}
+		<link rel="mask-icon" href="https://www.ft.com/__origami/service/image/v2/images/raw/ftlogo-v1%3Abrand-ft?source=update-logos&format=svg" color="#1a1817">
+		{{/if}}
 
 		{{#unless __disableIosSmartBanner}}
 		<meta name="apple-itunes-app" content="app-id=1200842933, affiliate-data=ct=smart-banner&pt=246269, app-argument={{#if canonicalUrl}}{{canonicalUrl}}{{else}}https://www.ft.com{{/if}}">


### PR DESCRIPTION
Adds a proper apple touch bar icon instead of it using the favicon which IMO looks a bit weird. However, because the icons must be white, and white on pink doesn't look very good, I've used the black background like the inverted header brand. (May need to speak to design about that to make sure they're ok with it) 

<img width="1085" alt="screenshot 2017-12-26 20 57 21" src="https://user-images.githubusercontent.com/11544418/34365063-fb6bcc6a-ea83-11e7-9fa9-a21907d1a139.png">

It also means it renders properly as a pinned tab in Safari rather than just the "F" on it's left
<img width="186" alt="screenshot 2017-12-26 21 32 36" src="https://user-images.githubusercontent.com/11544418/34365102-6dc4d37e-ea84-11e7-8f75-7c2a4f0fa737.png">
