### PR TITLE
.stylelintrc instead of .scss-lint.yml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@
 .DS_Store
 .editorconfig
 .eslintrc.js
-.scss-lint.yml
+.stylelintrc
 /public/__about.json
 /public/head-n-ui-core.css
 /public/main.css


### PR DESCRIPTION
*** Next developers***\nProjects making use of SCSS linting must now include .stylelintrc instead of .scss-lint.yml in .gitignore. Please commit your modified .gitignore

 🐿 v2.6.0

 - [ ]  TODO: Someone who groks SCSS should address the linting issues:
![image](https://user-images.githubusercontent.com/224547/34484896-9ffd1a6e-efbf-11e7-88dd-9414ebb24a59.png)
