### PR TITLE
At/n messaging client

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -23,7 +23,7 @@
     "n-desktop-app-banner": "^2.0.0",
     "n-image": "^5.0.0",
     "n-service-worker": "^1.8.0",
-    "n-messaging-client": "0.1.0-beta.2",
+    "n-messaging-client": "0.1.0-beta.4",
     "n-sliding-popup": "^2.0.0",
     "n-syndication": "^3.5.0",
     "n-topic-search": "^1.0.0",

--- a/bower.json
+++ b/bower.json
@@ -23,6 +23,7 @@
     "n-desktop-app-banner": "^2.0.0",
     "n-image": "^5.0.0",
     "n-service-worker": "^1.8.0",
+    "n-messaging-client": "0.1.0-beta.2",
     "n-sliding-popup": "^2.0.0",
     "n-syndication": "^3.5.0",
     "n-topic-search": "^1.0.0",

--- a/browser/js/app-initializer.js
+++ b/browser/js/app-initializer.js
@@ -8,6 +8,7 @@ import footer from 'o-footer';
 import { lazyLoad as lazyLoadImages } from 'n-image';
 import * as serviceWorker from 'n-service-worker';
 import DesktopAppBanner from 'n-desktop-app-banner';
+import { nMessagingClient } from 'n-messaging-client';
 import * as syndication from 'n-syndication';
 import { perfMark } from 'n-ui-foundations';
 
@@ -24,7 +25,8 @@ export const presets = {
 		cookieMessage: true,
 		ads: true,
 		syndication: true,
-		roe: true
+		roe: true,
+		messaging: false // todo: default off until tested
 	}
 };
 
@@ -120,6 +122,10 @@ export class AppInitializer {
 
 		if (this.enabledFeatures.lazyLoadImages) {
 			lazyLoadImages();
+		}
+
+		if (this.enabledFeatures.messaging) {
+			nMessagingClient.init();
 		}
 
 		// TODO - shouldn't it be possible to turn this off via the usual API?

--- a/browser/layout/wrapper.html
+++ b/browser/layout/wrapper.html
@@ -123,6 +123,9 @@
 			<div class="n-layout__row n-layout__row--header">
 				{{#outputBlock 'above-header'}}{{/outputBlock}}
 				{{>n-ui/header/template content=header}}
+				{{#if @root.__withMessaging}}
+					{{>n-messaging-client/templates/slot type='top'}}
+				{{/if}}
 			</div>
 			<div class="n-layout__row n-layout__row--content">
 				{{{body}}}
@@ -130,6 +133,10 @@
 
 			{{#if __enableDesktopAppBanner}}
 				{{>n-desktop-app-banner/templates/banner}}
+			{{/if}}
+
+			{{#if @root.__withMessaging}}
+				{{>n-messaging-client/templates/slot type='bottom'}}
 			{{/if}}
 
 			<div class="n-layout__row n-layout__row--footer">

--- a/browser/test/app-initializer.spec.js
+++ b/browser/test/app-initializer.spec.js
@@ -9,6 +9,7 @@ const tracking = require('../../components/n-ui/tracking');
 const sw = require('n-service-worker');
 const nImage = require('n-image');
 const syndication = require('n-syndication');
+const { nMessagingClient } = require('n-messaging-client');
 
 describe('AppInitializer', () => {
 	before(() => {
@@ -32,6 +33,7 @@ describe('AppInitializer', () => {
 		sinon.stub(sw, 'unregister');
 		sinon.stub(nImage, 'lazyLoad');
 		sinon.stub(syndication, 'init');
+		sinon.stub(nMessagingClient, 'init');
 	});
 
 	afterEach(() => {
@@ -48,6 +50,7 @@ describe('AppInitializer', () => {
 		sw.unregister.restore();
 		nImage.lazyLoad.restore();
 		syndication.init.restore();
+		nMessagingClient.init.restore();
 	});
 
 	describe('constructor', () => {
@@ -134,7 +137,8 @@ describe('AppInitializer', () => {
 				cookieMessage: true,
 				ads: true,
 				syndication: true,
-				roe: true
+				roe: true,
+				messaging: false
 			});
 		});
 
@@ -235,6 +239,16 @@ describe('AppInitializer', () => {
 		it('does not initialize lazy loaded images if feature is disabled', () => {
 			initApp({});
 			expect(nImage.lazyLoad.called).to.be.false;
+		});
+
+		it('initializes messaging if feature is enabled', () => {
+			initApp({messaging: true});
+			expect(nMessagingClient.init.called).to.be.true;
+		});
+
+		it('does not initialize messaging if feature is disabled', () => {
+			initApp({});
+			expect(nMessagingClient.init.called).to.be.false;
 		});
 
 		describe('after allStylesLoaded', () => {

--- a/demo/app.js
+++ b/demo/app.js
@@ -12,6 +12,7 @@ const app = module.exports = express({
 	systemCode: 'n-ui-test',
 	withFlags: true,
 	withHandlebars: true,
+	withMessaging: true,
 	withNavigation: true,
 	withAnonMiddleware: true,
 	withLayoutPolling: false,
@@ -24,7 +25,12 @@ const app = module.exports = express({
 	directory: process.cwd()
 });
 
-app.locals.nUiConfig = { preset: 'complete' };
+app.locals.nUiConfig = {
+	preset: 'complete',
+	features: {
+		messaging: true // todo: enable by default
+	}
+};
 
 app.use(require('./middleware/assets'));
 

--- a/demo/views/default.html
+++ b/demo/views/default.html
@@ -1,5 +1,6 @@
 <div id="site-content">
 	<p>{{@root.latestNUiVersions}}</p>
+	<p><strong>protip: Acess via local.ft.com for toggler flag cookies to work.</strong></p>
 	<p>lorem ipsum dolor sit down and listen to some latin</p>
 	<p>lorem ipsum dolor sit down and listen to some latin</p>
 	<p>lorem ipsum dolor sit down and listen to some latin</p>

--- a/main.scss
+++ b/main.scss
@@ -14,6 +14,7 @@ $n-ui-foundations-applied: true;
 
 @import 'n-syndication/main';
 @import 'n-desktop-app-banner/main';
+@import 'n-messaging-client/main';
 
 $o-cookie-message-is-silent: false;
 @import 'o-cookie-message/main';

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "@financial-times/n-desktop-app-banner": "^2.0.0",
     "@financial-times/n-express": "^19.3.0",
     "@financial-times/n-handlebars": "^1.17.9",
+    "@financial-times/n-messaging-client": "0.1.0-beta.2",
     "@financial-times/next-json-ld": "^0.2.1",
     "autoprefixer": "^7.1.5",
     "aws-sdk": "^2.130.0",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "@financial-times/n-desktop-app-banner": "^2.0.0",
     "@financial-times/n-express": "^19.3.0",
     "@financial-times/n-handlebars": "^1.17.9",
-    "@financial-times/n-messaging-client": "0.1.0-beta.2",
+    "@financial-times/n-messaging-client": "0.1.0-beta.4",
     "@financial-times/next-json-ld": "^0.2.1",
     "autoprefixer": "^7.1.5",
     "aws-sdk": "^2.130.0",

--- a/server/index.js
+++ b/server/index.js
@@ -1,5 +1,6 @@
 const nExpress = require('@financial-times/n-express');
 const nextJsonLd = require('@financial-times/next-json-ld');
+const nMessagingPresenter= require('@financial-times/n-messaging-client').presenter;
 const path = require('path');
 const fs = require('fs');
 
@@ -19,7 +20,7 @@ module.exports = options => {
 		// hack: shouldn't be able to turn off, but it makes writing tests SOOO much easier
 		withAssets: true,
 		withHandlebars: true,
-
+		withMessaging: false,
 		withJsonLd: false,
 		withBackendAuthentication: true,
 		withServiceMetrics: true,
@@ -114,6 +115,16 @@ module.exports = options => {
 
 	if (options.withAssets) {
 		assetManager.init(options, meta.directory, app);
+	}
+
+	if (options.withMessaging) {
+		// add n-messaging-client presenter
+		options.helpers = options.helpers || {};
+		options.helpers.nMessagingPresenter = nMessagingPresenter;
+		app.use(function (req, res, next) {
+			res.locals.__withMessaging = true;
+			next();
+		});
 	}
 
 	if (options.withHandlebars) {

--- a/server/test/n-express-opts.test.js
+++ b/server/test/n-express-opts.test.js
@@ -53,4 +53,35 @@ describe('configuring n-express', () => {
 		expect(nExpressOpts.healthChecks).to.equal(hc);
 		nExpress.getAppContainer.restore();
 	});
+
+	describe('n-messaging-client integration', () => {
+		it('should have messaging off by default in n-express', () => {
+			sinon.stub(nExpress, 'getAppContainer').callsFake(() => ({app: {
+				locals: {},
+				use: () => null
+			}, meta: {}, addInitPromise: () => null}));
+			nUi({
+				withAssets: false,
+				withHandlebars: false
+			});
+			const nExpressOpts = nExpress.getAppContainer.args[0][0];
+			expect(nExpressOpts.withMessaging).to.be.false;
+			nExpress.getAppContainer.restore();
+		});
+		it('should be able to over ride withMessaging boolean in n-express', () => {
+			sinon.stub(nExpress, 'getAppContainer').callsFake(() => ({app: {
+				locals: {},
+				use: () => null
+			}, meta: {}, addInitPromise: () => null}));
+			nUi({
+				withAssets: false,
+				withHandlebars: false,
+				withMessaging: true
+			});
+			const nExpressOpts = nExpress.getAppContainer.args[0][0];
+			expect(nExpressOpts.withMessaging).to.be.true;
+			nExpress.getAppContainer.restore();
+		});
+	});
+
 });

--- a/server/test/n-messaging-client.test.js
+++ b/server/test/n-messaging-client.test.js
@@ -7,7 +7,7 @@ describe('n-messaging-client Middleware', function () {
 	let app;
 	let locals;
 
-	context('enabled (via config)', function() {
+	context('enabled (via config)', function () {
 		before(function () {
 			app = nextExpress({ withFlags:true, withHandlebars:false, withAssets: false, withMessaging: true, systemCode: 'n-messaging-client'});
 			app.get('/', function (req, res) {
@@ -27,7 +27,7 @@ describe('n-messaging-client Middleware', function () {
 		});
 	});
 
-	context('default (disabled)', function() {
+	context('default (disabled)', function () {
 
 		before(function () {
 			app = nextExpress({ withFlags:true, withHandlebars:false, withAssets: false, systemCode: 'n-messaging-client'});

--- a/server/test/n-messaging-client.test.js
+++ b/server/test/n-messaging-client.test.js
@@ -1,0 +1,51 @@
+/*global describe, it, beforeEach*/
+const request = require('supertest');
+const nextExpress = require('../index');
+const expect = require('chai').expect;
+
+describe('n-messaging-client Middleware', function () {
+	let app;
+	let locals;
+
+	context('enabled (via config)', function() {
+		before(function () {
+			app = nextExpress({ withFlags:true, withHandlebars:false, withAssets: false, withMessaging: true, systemCode: 'n-messaging-client'});
+			app.get('/', function (req, res) {
+				locals = res.locals;
+				res.sendStatus(200).end();
+			});
+		});
+
+		it('Should set the res.locals.__withMessaging property', function (done) {
+			request(app)
+				.get('/')
+				.expect(function () {
+					expect(locals).to.have.own.property('__withMessaging');
+					expect(locals.__withMessaging).to.be.true;
+				})
+				.end(done);
+		});
+	});
+
+	context('default (disabled)', function() {
+
+		before(function () {
+			app = nextExpress({ withFlags:true, withHandlebars:false, withAssets: false, systemCode: 'n-messaging-client'});
+			app.get('/', function (req, res) {
+				locals = res.locals;
+				res.sendStatus(200).end();
+			});
+		});
+
+		it('Should set the res.locals.__withMessaging property', function (done) {
+			request(app)
+				.get('/')
+				.expect(function () {
+					expect(locals).to.not.have.own.property('__withMessaging');
+				})
+				.end(done);
+		});
+
+	});
+
+});


### PR DESCRIPTION
**See https://github.com/Financial-Times/n-messaging-client readme for more info**

**Why install globally in `n-ui`?**
If the end goal is to have consistent messaging across FT.com then it makes sense that it is an "easy to enable" `n-ui` feature.

----

This demonstrates how the new `n-messaging-client` _could_ be integrated with `n-ui` globally.
 
It would be `off` by default. To enable an application must invoke `n-express` with the `withMessaging` option (which will load the inject the templates and load the presenter). And enable the `messaging` feature in `nUiConfig` to load in the client side js.

```
const app = module.exports = express({
	withMessaging: true,
});

app.locals.nUiConfig = {
	preset: 'complete',
	features: {
		messaging: true
	}
};
```
  