### PR TITLE
a safer way to stringify error object

### DIFF
--- a/browser/bundles/o-errors.js
+++ b/browser/bundles/o-errors.js
@@ -16,7 +16,7 @@ oErrors.init({
 	},
 	filterError: function (reportedObject) {
 		// Supress errors if they contain an "Undefined not a.... evaluating window.FT.flags | .nUi | .ftNextUi type error"
-		const e = reportedObject.error.toString();
+		const e = Object.prototype.toString.call(reportedObject.error);
 		const windowFtError = !!e.match(/^(?=.*\bundefined\b)(?=.*(\bwindow.FT.flags\b|\bwindow.FT.nUi\b|\bwindow.FT.ftNextUi\b)).*$/gi);
 		return !(window.FT.disableOErrors || windowFtError);
 	},

--- a/browser/bundles/o-errors.js
+++ b/browser/bundles/o-errors.js
@@ -16,7 +16,7 @@ oErrors.init({
 	},
 	filterError: function (reportedObject) {
 		// Supress errors if they contain an "Undefined not a.... evaluating window.FT.flags | .nUi | .ftNextUi type error"
-		const e = Object.prototype.toString.call(reportedObject.error);
+		const e = String(reportedObject.error);
 		const windowFtError = !!e.match(/^(?=.*\bundefined\b)(?=.*(\bwindow.FT.flags\b|\bwindow.FT.nUi\b|\bwindow.FT.ftNextUi\b)).*$/gi);
 		return !(window.FT.disableOErrors || windowFtError);
 	},

--- a/browser/bundles/o-errors.js
+++ b/browser/bundles/o-errors.js
@@ -20,7 +20,7 @@ oErrors.init({
 		let windowFtError;
 		if ('error' in reportedObject) {
 				try {
-						windowFtError = String(reportedObject.error).match(/^(?=.*\bundefined\b)(?=.*(\bwindow.FT.flags\b|\bwindow.FT.nUi\b|\bwindow.FT.ftNextUi\b)).*$/gi);
+					windowFtError = String(reportedObject.error).match(/^.*\bundefined\b.*(\bwindow.FT.flags\b|\bwindow.FT.nUi\b|\bwindow.FT.ftNextUi\b).*$/i);
 				} catch (err) {
 					// could not stringify the error
 				}

--- a/browser/bundles/o-errors.js
+++ b/browser/bundles/o-errors.js
@@ -15,10 +15,19 @@ oErrors.init({
 		appName: appInfo.name
 	},
 	filterError: function (reportedObject) {
-		// Supress errors if they contain an "Undefined not a.... evaluating window.FT.flags | .nUi | .ftNextUi type error"
-		const e = String(reportedObject.error);
-		const windowFtError = !!e.match(/^(?=.*\bundefined\b)(?=.*(\bwindow.FT.flags\b|\bwindow.FT.nUi\b|\bwindow.FT.ftNextUi\b)).*$/gi);
-		return !(window.FT.disableOErrors || windowFtError);
+		// does the error contain an "undefined" followed by one of the below?
+		// "window.FT.flags", "window.FT.nUi" or "window.FT.ftNextUi"
+		let windowFtError;
+		if ('error' in reportedObject) {
+				try {
+						windowFtError = String(reportedObject.error).match(/^(?=.*\bundefined\b)(?=.*(\bwindow.FT.flags\b|\bwindow.FT.nUi\b|\bwindow.FT.ftNextUi\b)).*$/gi);
+				} catch (err) {
+					// could not stringify the error
+				}
+		}
+		// ignore if yes, or if o-errors is disabled
+		const ignore = windowFtError || window.FT.disableOErrors;
+		return !ignore;
 	},
 	errorBuffer: window.errorBuffer || []
 });


### PR DESCRIPTION
Big thanks to @JakeChampion for helping to make this more robust.