### PR TITLE
Run node-sass and postcss synchronously

### DIFF
--- a/scripts/build-sass.sh
+++ b/scripts/build-sass.sh
@@ -1,5 +1,15 @@
 #!/bin/sh
 
-rm -rf public/*.css
-node-sass ${1:-client/main.scss} --output-style compressed --include-path bower_components --include-path node_modules/@financial-times | \
-postcss --no-map --use autoprefixer postcss-discard-duplicates postcss-extract-css-block --autoprefixer.browsers "> 1% last 2 versions ie >= 9 ff ESR bb >= 7 iOS >= 5" --output ${2:-public/main.css}
+node-sass ${1:-client/main.scss} \
+--output-style compressed \
+--include-path bower_components \
+--include-path node_modules/@financial-times \
+--output ./tmp \
+&& \
+postcss ./tmp/main.css \
+--no-map \
+--use postcss-discard-duplicates autoprefixer postcss-extract-css-block \
+--autoprefixer.browsers "> 1% last 2 versions ie >= 9 ff ESR bb >= 7 iOS >= 5" \
+--output ${2:-public/main.css} \
+&& \
+rm -rf tmp \


### PR DESCRIPTION
Run node-sass and postcss synchronously, rather than streaming via a pipe (which can cause syntax errors).