### PR TITLE
correct regex for error filtering

### DIFF
--- a/browser/bundles/o-errors/filter-error.js
+++ b/browser/bundles/o-errors/filter-error.js
@@ -1,5 +1,7 @@
 module.exports = (reportedObject) => {
-	// FIXME: explain why it's okay to fitler these errors out
+	// we want to filter out errors that only occur
+	// when critical scripts fail to load - in that case
+	// the execution of JS is halted and we fall back to core
 	const errorFilter = /\bwindow\.FT\.(flags|nUi|ftNextUi) is undefined/i;
 	let windowFtError;
 	if ('error' in reportedObject) {

--- a/browser/bundles/o-errors/filter-error.js
+++ b/browser/bundles/o-errors/filter-error.js
@@ -1,8 +1,6 @@
-const errorFilter = /^(?=.*\bundefined\b)(?=.*(\bwindow.FT.flags\b|\bwindow.FT.nUi\b|\bwindow.FT.ftNextUi\b)).*$/gi;
-
 module.exports = (reportedObject) => {
-	// does the error contain an "undefined" followed by one of the below?
-	// "window.FT.flags", "window.FT.nUi" or "window.FT.ftNextUi"
+	// FIXME: explain why it's okay to fitler these errors out
+	const errorFilter = /\bwindow\.FT\.(flags|nUi|ftNextUi) is undefined/i;
 	let windowFtError;
 	if ('error' in reportedObject) {
 			try {

--- a/browser/bundles/o-errors/filter-error.js
+++ b/browser/bundles/o-errors/filter-error.js
@@ -1,15 +1,16 @@
+const errorFilter = /^(?=.*\bundefined\b)(?=.*(\bwindow.FT.flags\b|\bwindow.FT.nUi\b|\bwindow.FT.ftNextUi\b)).*$/gi;
+
 module.exports = (reportedObject) => {
 	// does the error contain an "undefined" followed by one of the below?
 	// "window.FT.flags", "window.FT.nUi" or "window.FT.ftNextUi"
 	let windowFtError;
 	if ('error' in reportedObject) {
 			try {
-				windowFtError = String(reportedObject.error).match(/^.*\bundefined\b.*(\bwindow.FT.flags\b|\bwindow.FT.nUi\b|\bwindow.FT.ftNextUi\b).*$/i);
+				windowFtError = !!String(reportedObject.error).match(errorFilter);
 			} catch (err) {
 				// could not stringify the error
 			}
 	}
-	// ignore if yes, or if o-errors is disabled
-	const ignore = windowFtError || window.FT.disableOErrors;
-	return !ignore;
+	// filter if yes, or if o-errors disabled
+	return !(windowFtError || window.FT.disableOErrors);
 };

--- a/browser/bundles/o-errors/test/filter-error.spec.js
+++ b/browser/bundles/o-errors/test/filter-error.spec.js
@@ -13,9 +13,9 @@ describe('filter error', () => {
 		'window.FT.ftNextUi is undefined',
 		'window.FT.nUi is undefined',
 		'window.FT.flags is undefined'
-	].map((filterError) => it(`should filter ${filterError}`, () => {
-		const result = filterError({ error: new Error(filterError) });
-		expect(result).to.equal(false);
+	].map(err => it(`should filter ${err}`, () => {
+			const result = filterError({ error: new Error(err) });
+			expect(result).to.equal(false);
 	}));
 
 });

--- a/browser/bundles/o-errors/test/filter-error.spec.js
+++ b/browser/bundles/o-errors/test/filter-error.spec.js
@@ -9,9 +9,13 @@ describe('filter error', () => {
 		expect(result).to.equal(true);
 	});
 
-	it('should filter undefined window.FT.ftNextUi error', () => {
-		const result = filterError({ error: new Error('undefined window.FT.ftNextUi') });
+	[
+		'window.FT.ftNextUi is undefined',
+		'window.FT.nUi is undefined',
+		'window.FT.flags is undefined'
+	].map((filterError) => it(`should filter ${filterError}`, () => {
+		const result = filterError({ error: new Error(filterError) });
 		expect(result).to.equal(false);
-	});
+	}));
 
 });


### PR DESCRIPTION
We want to filter out the following errors from `o-errors` output to reduce noise on Sentry:

- `window.FT.ftNextUi is undefined`
- `window.FT.nUi is undefined`
- `window.FT.flags is undefined`

These are caused by critical scripts on load error; the execution of JS is halted and we fall back to core when this happens so we don't really care about these errors.

[Here is a Beacon query](https://beacon.ft.com/data/query-wizard?query=javascript%3Aload-error-%3Ecount()-%3Egroup(context.script)-%3Efilter(context.script!~file)-%3ErelTime(this_24_hours)-%3Eprint(BarChart)) for script loading errors.

 🐿 v2.6.0