### PR TITLE
don't track sw flags if sw not supported

### DIFF
--- a/components/n-ui/speedcurve-lux/index.js
+++ b/components/n-ui/speedcurve-lux/index.js
@@ -4,8 +4,10 @@ function addAbStateDataToLux () {
 	if (dataAbState && dataAbState !== '-') {
 		dataAbState.split(/\s*,\s*/)
 			.map(test => test.split(/\s*:\s*/))
-			.map(test => ({ flagName: test[0], variant: test[1] }))
-			.forEach(test => window.LUX.addData(test.flagName, test.variant));
+			.map(([flagName, variant]) => ({ flagName, variant }))
+			// only include sw flags if sw is supported
+			.filter(({flagName}) => !/^sw[A-Z]/.test(flagName) || navigator.serviceWorker)
+			.forEach(({ flagName, variant }) => window.LUX.addData(flagName, variant));
 	}
 }
 

--- a/components/n-ui/speedcurve-lux/test/index.spec.js
+++ b/components/n-ui/speedcurve-lux/test/index.spec.js
@@ -14,7 +14,7 @@ describe('Speedcurve LUX', () => {
 
 			speedcurveLux.addFlags();
 
-			expect(window.LUX.addData).to.have.been.calledWith('swAdsCaching', 'control');
+			expect(window.LUX.addData).to.have.been.calledWith('headlineTesting', 'variant2');
 		});
 
 		it('should add flags after LUX script loads', () => {


### PR DESCRIPTION
Because otherwise our mobile data is swamped by iOS and difficult to detect the size of the effect.