### PR TITLE
Error page login patch

### DIFF
--- a/server/models/navigation/navigationModelV2.js
+++ b/server/models/navigation/navigationModelV2.js
@@ -66,7 +66,7 @@ module.exports = class NavigationModelV2 {
 		const currentPathName = url.parse(currentUrl).pathname;
 		for(let item of navData.items){
 			if(typeof item.url === 'string' && item.url.includes('${currentPath}')){
-				if(!currentPathName || !/\/(products|barriers)/.test(currentPathName)) {
+				if(!currentPathName || !/\/(products|barriers|errors)/.test(currentPathName)) {
 					item.url = item.url.replace('${currentPath}', currentUrl);
 				} else {
 					item.url = item.url.replace('${currentPath}', '%2F');


### PR DESCRIPTION
Currently error page login links look like `https://www.ft.com/login?location=/errors/page/5xx`.

So after logging in you end up at `https://www.ft.com/errors/page/5xx`, kinda useless.