### PR TITLE
Pass ammit allocations with the event context

### DIFF
--- a/components/n-ui/tracking/ft/index.js
+++ b/components/n-ui/tracking/ft/index.js
@@ -98,6 +98,16 @@ const oTrackingWrapper = {
 				}
 			}
 
+			const abState = getRootData('ab-state');
+			if (abState && abState !== '-') {
+				const ammitAllocations = {};
+				abState.split(',').map(flag => {
+					const [name, value] = flag.split(':');
+					ammitAllocations[name] = value;
+				});
+				context['active_ammit_flags'] = ammitAllocations;
+			}
+
 			oTracking.init({
 				server: 'https://spoor-api.ft.com/ingest',
 				context: context,

--- a/components/n-ui/tracking/ft/index.js
+++ b/components/n-ui/tracking/ft/index.js
@@ -99,12 +99,17 @@ const oTrackingWrapper = {
 			}
 
 			const abState = getRootData('ab-state');
-			if (abState && abState !== '-') {
-				const ammitAllocations = {};
-				abState.split(',').map(flag => {
-					const [name, value] = flag.split(':');
-					ammitAllocations[name] = value;
-				});
+			if (abState) {
+				let ammitAllocations = abState;
+
+				if (abState !== '-') {
+					ammitAllocations = {};
+					abState.split(',').map(flag => {
+						const [name, value] = flag.split(':');
+						ammitAllocations[name] = value;
+					});
+				}
+
 				context['active_ammit_flags'] = ammitAllocations;
 			}
 


### PR DESCRIPTION
 🐿 v2.7.0

The ammit allocations for a given user exist on the `data-ab-state` attribute of the html tag. This change passes an `active_ammit_flags` object into the o-tracking context so the ammit data is sent with every event. 

@tbergmen @missamynicholson 