### PR TITLE
Slightly more optimal CTM

### DIFF
--- a/browser/layout/partials/ctm.html
+++ b/browser/layout/partials/ctm.html
@@ -2,17 +2,15 @@
 var classes = document.documentElement.className; {{!note: once we ditch support for ie9 we can just use classlist}}
 classes = classes.replace(/\bno-js\b/, 'js'); {{!note: needed for JS that's run out of the scope of the bootstrap (inline onclicks, etc)}}
 
-var supportsBlobConstructor = typeof Blob === 'function';
 var script = document.createElement('script');
 var supportsDeferredScripts = "defer" in script && "async" in script;
 
 window.cutsTheMustard = (
-	typeof Function.prototype.bind !== 'undefined'
-	&& typeof document.documentElement.dataset === 'object'
-	&& ('withCredentials' in new XMLHttpRequest())
-	&& supportsBlobConstructor
+	typeof document.documentElement.dataset === 'object'
+	&& ('visibilityState' in document)
 	&& supportsDeferredScripts
 	);
+
 if (window.cutsTheMustard) {
 	classes = classes.replace(/\bcore\b/, 'enhanced');
 }

--- a/browser/layout/partials/ctm.html
+++ b/browser/layout/partials/ctm.html
@@ -2,11 +2,7 @@
 var classes = document.documentElement.className; {{!note: once we ditch support for ie9 we can just use classlist}}
 classes = classes.replace(/\bno-js\b/, 'js'); {{!note: needed for JS that's run out of the scope of the bootstrap (inline onclicks, etc)}}
 
-var supportsBlobConstructor = false;
-try {
-	new Blob;
-	supportsBlobConstructor = true;
-} catch (e) {}
+var supportsBlobConstructor = typeof Blob === 'function';
 var script = document.createElement('script');
 var supportsDeferredScripts = "defer" in script && "async" in script;
 


### PR DESCRIPTION
Very minor optimisation, but constructing a blob is up to 1000 times slower than `typeof Blob (https://jsperf.com/blobs), and evaluating this sometimes takes up to 40ms.

<img width="295" alt="screen shot 2018-02-21 at 16 08 58" src="https://user-images.githubusercontent.com/1978880/36491398-9325b186-1722-11e8-8c2e-9eae491aa52e.png">

(note: need to check that Blob isn't still a function in Android 4 - which is what this test was designed to exclude)