### PR TITLE
run webfonts loader script only when necessary, and put it behind a flag

### DIFF
--- a/server/lib/asset-manager/middleware-factory.js
+++ b/server/lib/asset-manager/middleware-factory.js
@@ -58,7 +58,7 @@ module.exports = ({
 				}),
 			);
 
-			if (res.locals.flags.webfonts && !req.cookies['o-typography-fonts-loaded']) {
+			if (res.locals.flags.webfonts && !(req.cookies && req.cookies['o-typography-fonts-loaded'])) {
 				res.locals.javascriptBundles.push(
 					getBundleConfig({
 						file: 'font-loader.js',

--- a/server/lib/asset-manager/middleware-factory.js
+++ b/server/lib/asset-manager/middleware-factory.js
@@ -56,10 +56,18 @@ module.exports = ({
 					url: res.locals.polyfillIo.enhanced,
 					stopsExecutionOnLoadError: true
 				}),
-				getBundleConfig({
-					file: 'font-loader.js',
-					isNUi: true
-				}),
+			);
+
+			if (res.locals.flags.webfonts && !req.cookies['o-typography-fonts-loaded']) {
+				res.locals.javascriptBundles.push(
+					getBundleConfig({
+						file: 'font-loader.js',
+						isNUi: true
+					})
+				);
+			}
+
+			res.locals.javascriptBundles.push(
 				getBundleConfig({
 					file: 'o-errors.js',
 					isNUi: true

--- a/server/lib/asset-manager/middleware-factory.js
+++ b/server/lib/asset-manager/middleware-factory.js
@@ -58,7 +58,7 @@ module.exports = ({
 				}),
 			);
 
-			if (res.locals.flags.webfonts && !(req.cookies && req.cookies['o-typography-fonts-loaded'])) {
+			if (res.locals.flags.webfonts) {
 				res.locals.javascriptBundles.push(
 					getBundleConfig({
 						file: 'font-loader.js',


### PR DESCRIPTION
webfonts loader script:
1. put it behind a flag
2. include it only if fonts aren't already present