### PR TITLE
Broadcast tracking events for timing thresholds

### DIFF
--- a/components/n-ui/tracking/ft/events/time-on-page.js
+++ b/components/n-ui/tracking/ft/events/time-on-page.js
@@ -1,0 +1,19 @@
+const { broadcast } = require('n-ui-foundations');
+
+const timeThresholdEvents = (thresholdsInSeconds) => {
+	thresholdsInSeconds.forEach(timeout => setTimeout(() => {
+		broadcast('oTracking.event', {
+			action: 'time-threshold',
+			category: 'page',
+			context: {
+				'time-threshold': timeout
+			}
+		});
+	}, timeout * 1000));
+};
+
+module.exports = {
+	init: (thresholdsInSeconds = [30, 60, 90]) => {
+		timeThresholdEvents(thresholdsInSeconds);
+	}
+};

--- a/components/n-ui/tracking/ft/next-events.js
+++ b/components/n-ui/tracking/ft/next-events.js
@@ -3,6 +3,7 @@ const Timing = require('./events/navigation-timing');
 const Copy = require('./events/copy');
 const Attention = require('./events/page-attention');
 const Positional = require('./events/positional');
+const timeOnPage = require('./events/time-on-page');
 
 const NextEvents = function () {};
 
@@ -20,6 +21,9 @@ NextEvents.prototype.init = function () {
 
 	this.positional = new Positional();
 	this.positional.init(document);
+
+	// track time spent on page at set thresholds
+	timeOnPage.init();
 
 	// Nav timing - https://developer.mozilla.org/en-US/docs/Navigation_timing
 	new Timing().track();

--- a/components/n-ui/tracking/test/ft/events/time-on-page.spec.js
+++ b/components/n-ui/tracking/test/ft/events/time-on-page.spec.js
@@ -1,0 +1,58 @@
+/*global describe, it, expect, before, after*/
+const sinon = require('sinon');
+const tracking = require('../../../ft/events/time-on-page');
+
+const oTrackingListener = sinon.stub();
+
+describe('#TimeThresholdEvent', () => {
+	let clock;
+
+	before(() => {
+		clock = sinon.useFakeTimers();
+		document.body.addEventListener('oTracking.event', (e) => {
+			oTrackingListener(e.detail);
+		});
+
+		tracking.init();
+	});
+
+	after(() => {
+		clock.restore();
+	});
+
+	it('should emit a tracking event after 30s', () => {
+		clock.tick(30000);
+
+		expect(oTrackingListener).to.have.been.calledWithMatch({
+			action: 'time-threshold',
+			category: 'page',
+			context: {
+				'time-threshold': 30
+			}
+		});
+	});
+
+	it('should emit a tracking event after 60s', () => {
+		clock.tick(60000);
+
+		expect(oTrackingListener).to.have.been.calledWithMatch({
+			action: 'time-threshold',
+			category: 'page',
+			context: {
+				'time-threshold': 60
+			}
+		});
+	});
+
+	it('should emit a tracking event after 90s', () => {
+		clock.tick(90000);
+
+		expect(oTrackingListener).to.have.been.calledWithMatch({
+			action: 'time-threshold',
+			category: 'page',
+			context: {
+				'time-threshold': 90
+			}
+		});
+	});
+});


### PR DESCRIPTION
As part of creating an "article read" metric, we want the ability to know if a person spent 30, 60, 90 seconds on a page - regardless of whether or not they bounce.

This replaces the [code originally added to next-article](https://github.com/Financial-Times/next-article/pull/2694) as the data team would like this to run on all pages.

🐿 v2.7.0