### PR TITLE
Fixed filter errors

### DIFF
--- a/browser/bundles/o-errors/filter-error.js
+++ b/browser/bundles/o-errors/filter-error.js
@@ -1,4 +1,4 @@
-module.exports = ({ error }) => {
+module.exports = ({ exception }) => {
 	// we want to filter out errors that only occur
 	// when critical scripts fail to load - in that case
 	// the execution of JS is halted and we fall back to core
@@ -7,15 +7,14 @@ module.exports = ({ error }) => {
 		/undefined is|is undefined/i
 	];
 	let windowFtError;
-	if(error) {
+	if(exception) {
 		try {
-			let errorString = String(error);
+			let errorString = String(exception);
 			windowFtError = errorFilters.every(rx => rx.test(errorString));
 		} catch (err) {
-			// could not stringify the error
+			// could not stringify the exception
 		}
 	}
-
 	// filter if yes, or if o-errors disabled
 	return !(windowFtError || window.FT.disableOErrors);
 };

--- a/browser/bundles/o-errors/test/filter-error.spec.js
+++ b/browser/bundles/o-errors/test/filter-error.spec.js
@@ -5,7 +5,7 @@ const filterError = require('../filter-error');
 describe('filter error', () => {
 
 	it('should not filter Trump error', () => {
-		const result = filterError({ error: new Error('Trump') });
+		const result = filterError({ exception: new Error('Trump') });
 		expect(result).to.equal(true);
 	});
 
@@ -16,7 +16,7 @@ describe('filter error', () => {
 		'undefined is not an object (evaluating \'window.FT.nUi._hiddenComponents\')',
 		'undefined is not a function (evaluating \'Object.assign(window.FT.flags'
 	].map(err => it(`should filter ${err}`, () => {
-			const result = filterError({ error: new Error(err) });
+			const result = filterError({ exception: new Error(err) });
 			expect(result).to.equal(false);
 	}));
 


### PR DESCRIPTION
One of the keys from the callback argument object changed from `error` to `exception`. Who knew.