### PR TITLE
Include focus visible polyfill

### DIFF
--- a/browser/js/app-initializer.js
+++ b/browser/js/app-initializer.js
@@ -11,6 +11,9 @@ import * as syndication from 'n-syndication';
 import { perfMark } from 'n-ui-foundations';
 import speedcurveLux from '../../components/n-ui/speedcurve-lux';
 
+//Polyfill for :focus-visible https://github.com/WICG/focus-visible
+import 'focus-visible';
+
 export const presets = {
 	discrete: {
 		header: true,

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "colors": "^1.1.2",
     "commander": "^2.14.1",
     "concurrently": "^3.5.1",
+    "focus-visible": "^4.1.0",
     "fs-extra": "^5.0.0",
     "ft-poller": "^2.9.4",
     "handlebars-loader": "^1.6.0",


### PR DESCRIPTION
To make https://github.com/Financial-Times/o-normalise/releases/tag/v1.6.0 work

Before:
Focus state shows on tabs and clicks
![focus-visible-before](https://user-images.githubusercontent.com/1978880/37284130-51e0fe40-25f2-11e8-8ca7-f4d9df85eb48.gif)

After:
Focus state only shows on keyboard interaction (the o-normalise PR has more details)
![focus-visible-after](https://user-images.githubusercontent.com/1978880/37284135-53a1737c-25f2-11e8-99f4-26d36116bb5b.gif)
