### PR TITLE
Use aria-current instead of aria-selected

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -32,7 +32,7 @@
     "o-errors": "^3.5.1",
     "o-expander": "^4.2.2",
     "o-footer": "^6.0.0",
-    "o-header": "^7.1.0",
+    "o-header": "^7.2.10",
     "o-tracking": "^1.3.5",
     "logo-images": "^1.5.2"
   }

--- a/components/n-ui/header/partials/drawer/template.html
+++ b/components/n-ui/header/partials/drawer/template.html
@@ -1,6 +1,6 @@
 {{#*inline "DrawerParentItem"}}
 	<div class="o-header__drawer-menu-toggle-wrapper">
-		<a class="o-header__drawer-menu-link o-header__drawer-menu-link--parent o-header__drawer-menu-link--{{#if selected}}selected{{else}}unselected{{/if}}" href="{{url}}" {{#selected}}aria-label="Current page" aria-selected="true"{{/selected}} data-trackable="{{label}}">{{label}}</a>
+		<a class="o-header__drawer-menu-link o-header__drawer-menu-link--parent o-header__drawer-menu-link--{{#if selected}}selected{{else}}unselected{{/if}}" href="{{url}}" {{#if selected}}aria-label="Current page" aria-current="true"{{/if}} data-trackable="{{label}}">{{label}}</a>
 		<button class="o-header__drawer-menu-toggle o-header__drawer-menu-toggle--{{#if selected}}selected{{else}}unselected{{/if}}" aria-controls="o-header-drawer-child-{{@index}}" data-trackable="sub-level-toggle | {{label}}">
 			Show more {{label}} links
 		</button>
@@ -8,18 +8,18 @@
 	<ul class="o-header__drawer-menu-list o-header__drawer-menu-list--child" id="o-header-drawer-child-{{@index}}" data-trackable="sub-level">
 		{{#each submenu.items}}
 		<li class="o-header__drawer-menu-item">
-			<a class="o-header__drawer-menu-link o-header__drawer-menu-link--child o-header__drawer-menu-link--{{#if selected}}selected{{else}}unselected{{/if}}" href="{{url}}" {{#selected}}aria-label="Current page" aria-selected="true"{{/selected}} data-trackable="{{label}}">{{label}}</a>
+			<a class="o-header__drawer-menu-link o-header__drawer-menu-link--child o-header__drawer-menu-link--{{#if selected}}selected{{else}}unselected{{/if}}" href="{{url}}" {{#if selected}}aria-label="Current page" aria-current="true"{{/if}} data-trackable="{{label}}">{{label}}</a>
 		</li>
 		{{/each}}
 	</ul>
 {{/inline}}
 
 {{#*inline "DrawerSingleItem"}}
-	<a class="o-header__drawer-menu-link o-header__drawer-menu-link--{{#if selected}}selected{{else}}unselected{{/if}}" href="{{url}}" {{#selected}}aria-label="Current page" aria-selected="true"{{/selected}} data-trackable="{{label}}">{{label}}</a>
+	<a class="o-header__drawer-menu-link o-header__drawer-menu-link--{{#if selected}}selected{{else}}unselected{{/if}}" href="{{url}}" {{#if selected}}aria-label="Current page" aria-current="true"{{/if}} data-trackable="{{label}}">{{label}}</a>
 {{/inline}}
 
 {{#*inline "DrawerSpecialItem"}}
-	<a class="o-header__drawer-menu-link o-header__drawer-menu-link--secondary o-header__drawer-menu-link--{{#if selected}}selected{{else}}unselected{{/if}}" href="{{url}}" {{#selected}}aria-label="Current page" aria-selected="true"{{/selected}} data-trackable="{{label}}">{{label}}</a>
+	<a class="o-header__drawer-menu-link o-header__drawer-menu-link--secondary o-header__drawer-menu-link--{{#if selected}}selected{{else}}unselected{{/if}}" href="{{url}}" {{#if selected}}aria-label="Current page" aria-current="true"{{/if}} data-trackable="{{label}}">{{label}}</a>
 {{/inline}}
 
 <div class="o-header__drawer" id="o-header-drawer" role="navigation" aria-label="Drawer menu" data-o-header-drawer data-o-header-drawer--no-js data-trackable="drawer" data-trackable-terminate>

--- a/components/n-ui/header/partials/header/nav.html
+++ b/components/n-ui/header/partials/header/nav.html
@@ -3,7 +3,7 @@
 		<ul class="o-header__nav-list">
 			{{#each @root.navigation.menus.navbar-simple.items}}
 				<li class="o-header__nav-item">
-					<a class="o-header__nav-link o-header__nav-link--primary" href="{{url}}" {{#selected}}aria-label="Current page" aria-selected="true"{{/selected}} data-trackable="{{name}}">{{label}}</a>
+					<a class="o-header__nav-link o-header__nav-link--primary" href="{{url}}" {{#if selected}}aria-label="Current page" aria-current="true"{{/if}} data-trackable="{{name}}">{{label}}</a>
 				</li>
 			{{/each}}
 		</ul>
@@ -15,7 +15,7 @@
 		<ul class="o-header__nav-list o-header__nav-list--left" data-trackable="primary-nav">
 			{{#each @root.navigation.menus.navbar.items}}
 			<li class="o-header__nav-item">
-				<a class="o-header__nav-link o-header__nav-link--primary {{#ifEquals @root.currentNav.topLevelRelative.href href}}o-header-nav__list-link--highlight{{/ifEquals}}" href="{{url}}" id="o-header-link-{{@index}}" {{#selected}}aria-label="Current page" aria-selected="true"{{/selected}} data-trackable="{{label}}">{{label}}</a>
+				<a class="o-header__nav-link o-header__nav-link--primary {{#ifEquals @root.currentNav.topLevelRelative.href href}}o-header-nav__list-link--highlight{{/ifEquals}}" href="{{url}}" id="o-header-link-{{@index}}" {{#if selected}}aria-label="Current page" aria-current="true"{{/if}} data-trackable="{{label}}">{{label}}</a>
 				{{> n-ui/header/partials/meganav/template}}
 			</li>
 			{{/each}}

--- a/components/n-ui/header/partials/meganav/sectionlist.html
+++ b/components/n-ui/header/partials/meganav/sectionlist.html
@@ -5,7 +5,7 @@
 				{{#each data}}
 					{{#each this}}
 						<li class="o-header__mega-item">
-							<a class="o-header__mega-link" href="{{url}}" {{#selected}}aria-label="Current page" aria-selected="true"{{/selected}} data-trackable="link">
+							<a class="o-header__mega-link" href="{{url}}" {{#if selected}}aria-label="Current page" aria-current="true"{{/if}} data-trackable="link">
 								{{label}}
 							</a>
 						</li>

--- a/components/n-ui/header/partials/subnav/template.html
+++ b/components/n-ui/header/partials/subnav/template.html
@@ -10,7 +10,7 @@
 							<ol class="o-header__subnav-list o-header__subnav-list--breadcrumb" aria-label="Breadcrumb" data-trackable="breadcrumb">
 								{{#each @root.navigation.breadcrumb}}
 								<li class="o-header__subnav-item">
-									<a class="o-header__subnav-link {{#if selected}}o-header__subnav-link--highlight{{/if}}" href="{{url}}" aria-selected="{{selected}}" data-trackable="{{label}}">
+									<a class="o-header__subnav-link {{#if selected}}o-header__subnav-link--highlight{{/if}}" href="{{url}}" {{#if selected}}aria-current="true"{{/if}} data-trackable="{{label}}">
 										{{label}}
 									</a>
 								</li>
@@ -22,7 +22,7 @@
 							<ul class="o-header__subnav-list o-header__subnav-list--subsections" aria-label="Subsections" data-trackable="subsections">
 								{{#each @root.navigation.subsections}}
 								<li class="o-header__subnav-item">
-									<a class="o-header__subnav-link {{#if selected}}o-header__subnav-link--highlight{{/if}}" href="{{url}}" aria-selected="{{selected}}" data-trackable="{{label}}">
+									<a class="o-header__subnav-link {{#if selected}}o-header__subnav-link--highlight{{/if}}" href="{{url}}" {{#if selected}}aria-current="true"{{/if}} data-trackable="{{label}}">
 										{{label}}
 									</a>
 								</li>


### PR DESCRIPTION
…to identify current page/section in navigation.

Requires `o-header` 7.2.10 or newer.