### PR TITLE
Added validateAdsTraffic in ads config

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -27,7 +27,7 @@
     "n-topic-search": "^1.0.0",
     "n-ui-foundations": "^3.0.0",
     "next-session-client": "^2.3.1",
-    "o-ads": "^7.1.6",
+    "o-ads": "^8.2.1",
     "o-cookie-message": "^3.1.1",
     "o-errors": "^3.5.1",
     "o-expander": "^4.2.2",

--- a/components/n-ui/ads/js/oAdsConfig.js
+++ b/components/n-ui/ads/js/oAdsConfig.js
@@ -21,6 +21,7 @@ module.exports = function (flags, appName, adOptions) {
 		}
 	};
 
+	const validateAdsTrafficApi = (flags.get('validateAdsTraffic')) ? `${apiUrlRoot}validate-traffic` : null;
 
 	function getContextualTargeting (appName) {
 		let uuid;
@@ -105,7 +106,8 @@ module.exports = function (flags, appName, adOptions) {
 			user: `${apiUrlRoot}user`,
 			page: getContextualTargeting(appName),
 			usePageZone: true
-		}
+		},
+		validateAdsTrafficApi
 	};
 
 };


### PR DESCRIPTION
 🐿 v2.8.0

This enables validation of traffic on ft.com before serving ads. 

**CHECK FLAG IS SET CORRECTLY BEFORE MERGING**