### PR TITLE
enable css source maps in development

### DIFF
--- a/build/app/cli.js
+++ b/build/app/cli.js
@@ -64,8 +64,10 @@ program
 
 		const script = './node_modules/@financial-times/n-ui/scripts/build-sass.sh';
 		const commands = {
-			'jsOnly': `'webpack --bail --config ${webpackConfPath} ${options.production ? '-p' : ''}'`,
-			'sassOnly': cssEntryPoints.map(([target, entry]) => `'${script} ${entry} ${target}'`).join(' ')
+			jsOnly: `'webpack --bail --config ${webpackConfPath} ${options.production ? '-p' : ''}'`,
+			sassOnly: `export CSS_SOURCE_MAPS=${!options.production} && ${cssEntryPoints
+				.map(([target, entry]) => `'${script} ${entry} ${target}'`)
+				.join(' ')}`
 		};
 
 		for(let key in commands) {

--- a/scripts/build-sass.sh
+++ b/scripts/build-sass.sh
@@ -4,6 +4,7 @@
 # E.g. ./client/comments.scss returns comments.scss
 
 node-sass ${1:-client/main.scss} \
+${CSS_SOURCE_MAPS:+--source-map true} \
 --output-style compressed \
 --include-path bower_components \
 --include-path node_modules/@financial-times \


### PR DESCRIPTION
 Just an idea – CSS source maps are helpful for debugging.
🐿 v2.7.0