### PR TITLE
add postcss config to apply plugins options

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "@financial-times/n-express": "^19.8.0",
     "@financial-times/n-handlebars": "^1.19.4",
     "@financial-times/next-json-ld": "^0.3.0",
-    "autoprefixer": "^7.2.5",
+    "autoprefixer": "^8.0.0",
     "aws-sdk": "^2.190.0",
     "babel-core": "^6.26.0",
     "babel-loader": "^7.1.2",

--- a/scripts/build-sass.sh
+++ b/scripts/build-sass.sh
@@ -12,9 +12,7 @@ node-sass ${1:-client/main.scss} \
 scssfile=${1##*/}
 cssfile=${scssfile//"scss"/"css"}
 postcss ./tmp/${cssfile:-main.css} \
---no-map \
---use postcss-discard-duplicates autoprefixer postcss-extract-css-block \
---autoprefixer.browsers "> 1% last 2 versions ie >= 9 ff ESR bb >= 7 iOS >= 5" \
+--config "$(dirname "${BASH_SOURCE[0]}")/postcss.config.js" \
 --output ${2:-public/main.css} \
 && \
 rm -rf ./tmp/${cssfile:-main.css}

--- a/scripts/postcss.config.js
+++ b/scripts/postcss.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+	map: false,
+	plugins: [
+		require('postcss-discard-duplicates')(),
+		require('autoprefixer')({ browsers: '> 1%, last 2 versions, ie >= 9, ff ESR, bb >= 7, iOS >= 5', grid: true }),
+		require('postcss-extract-css-block')()
+	]
+}


### PR DESCRIPTION
postcss hasn't passed plugins(autoprefixer)'s option properly. I have added a postcss config file, and also set grid option in it.

Setting postcss config file is suggested in this issue.
https://github.com/postcss/postcss-cli/issues/144
 🐿 v2.8.0