### PR TITLE
Fix (I think) make build-production breaking

### DIFF
--- a/build/app/cli.js
+++ b/build/app/cli.js
@@ -65,8 +65,8 @@ program
 		const script = './node_modules/@financial-times/n-ui/scripts/build-sass.sh';
 		const commands = {
 			jsOnly: `'webpack --bail --config ${webpackConfPath} ${options.production ? '-p' : ''}'`,
-			sassOnly: `export CSS_SOURCE_MAPS=${!options.production} && ${cssEntryPoints
-				.map(([target, entry]) => `'${script} ${entry} ${target}'`)
+			sassOnly: `${cssEntryPoints
+				.map(([target, entry]) => `'export CSS_SOURCE_MAPS=${!options.production} && ${script} ${entry} ${target}'`)
 				.join(' ')}`
 		};
 


### PR DESCRIPTION
I'm guessing something weird with concurrently and quote marks.

Also, assuming that all the concurrent commands run in a spawned process, probably want to export CSS_SOURCE_MAPS in each of them? 🤷‍♂️ 