### PR TITLE
Allow header logo to not be a link

### DIFF
--- a/components/n-ui/header/partials/header/top.html
+++ b/components/n-ui/header/partials/header/top.html
@@ -18,12 +18,21 @@
 				</div>
 			{{/unlessEquals}}
 			<div class="o-header__top-column o-header__top-column--center">
+				{{#unlessEquals nUi.header.logoLink false}}
 				<a class="o-header__top-logo {{#if @root.flags.perfJanky}}o-header__top-logo--inlined{{/if}}" data-trackable="logo" href="/" title="Go to Financial Times homepage">
 					{{#if @root.flags.perfJanky}}
 						{{#inline file='logo-images/src/brand-ft-masthead.svg'}}{{/inline}}
 					{{/if}}
 					<span class="o-header__visually-hidden">Financial Times</span>
 				</a>
+				{{else}}
+				<div class="o-header__top-logo {{#if @root.flags.perfJanky}}o-header__top-logo--inlined{{/if}}">
+					{{#if @root.flags.perfJanky}}
+						{{#inline file='logo-images/src/brand-ft-masthead.svg'}}{{/inline}}
+					{{/if}}
+					<span class="o-header__visually-hidden">Financial Times</span>
+				</div>
+				{{/unlessEquals}}
 			</div>
 			{{#unlessEquals nUi.header.variant 'logo-only'}}
 				<div class="o-header__top-column o-header__top-column--right">


### PR DESCRIPTION
For when page is linked to from iOS app and no nav should be available

 🐿 v2.8.0