### PR TITLE
Add nUi config option to hide footer

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,9 @@ This should all be passed as part of the object that is the second argument of r
         header: {
             variant: 'logo-only',
             logoLink: false
+        },
+        footer: {
+        	hide: true
         }
     }
 }

--- a/browser/layout/wrapper.html
+++ b/browser/layout/wrapper.html
@@ -132,6 +132,7 @@
 				{{{body}}}
 			</div>
 
+			{{#unlessEquals nUi.footer.hide true}}
 			<div class="n-layout__row n-layout__row--footer">
 				{{#outputBlock 'footer'}}{{/outputBlock}}
 				{{>n-ui/footer/template}}
@@ -139,6 +140,7 @@
 					{{>n-ui/header/partials/drawer/template}}
 				{{/unlessEquals}}
 			</div>
+			{{/unlessEquals}}
 		</div>
 	{{>layout/partials/bootstrapper}}
 	{{>n-ui/tracking/templates/core-analytics}}


### PR DESCRIPTION
To block all outbound links from the page if the user comes from iOS app, similar to recent [header changes](https://github.com/Financial-Times/n-ui/pull/1222#issuecomment-379693416)

 🐿 v2.8.0