### PR TITLE
Add Fastly insights (RUM for CDN)

### DIFF
--- a/browser/layout/partials/fastly-insights.html
+++ b/browser/layout/partials/fastly-insights.html
@@ -1,0 +1,1 @@
+<script defer src="https://www.fastly-insights.com/insights.js?k=8d2aeb08-16bf-4429-88ff-78f0dca00004"></script>   

--- a/browser/layout/partials/fastly-insights.html
+++ b/browser/layout/partials/fastly-insights.html
@@ -1,1 +1,1 @@
-<script defer src="https://www.fastly-insights.com/insights.js?k=8d2aeb08-16bf-4429-88ff-78f0dca00004"></script>   
+<script defer src="https://www.fastly-insights.com/insights.js?k=8d2aeb08-16bf-4429-88ff-78f0dca00004"></script>

--- a/browser/layout/vanilla.html
+++ b/browser/layout/vanilla.html
@@ -28,5 +28,8 @@
 	<body class="o-hoverable-on" data-next-is-logged-in="{{@root.anon.userIsLoggedIn}}" data-trackable="page:{{@root.__name}}{{#if @root.trackablePageName}}/{{@root.trackablePageName}}{{/if}}">
 		{{{body}}}
 		{{>layout/partials/bootstrapper}}
+		{{#if @root.flags.fastlyInsights}}
+		{{>layout/partials/fastly-insights}}
+		{{/if}}
 	</body>
 </html>

--- a/browser/layout/wrapper.html
+++ b/browser/layout/wrapper.html
@@ -145,9 +145,11 @@
 	{{>layout/partials/bootstrapper}}
 	{{>n-ui/tracking/templates/core-analytics}}
 	{{>n-service-worker/appcache/iframe}}
-
 	{{#if @root.flags.qualtrics}}
 		{{>layout/partials/qualtrics-tag}}
+	{{/if}}
+	{{#if @root.flags.fastlyInsights}}
+		{{>layout/partials/fastly-insights}}
 	{{/if}}
 	</body>
 </html>

--- a/secret-squirrel.js
+++ b/secret-squirrel.js
@@ -82,7 +82,8 @@ module.exports = {
 			'0fee75c6-dd73-11e6-9d7c-be108f1c1dce', // server/test/stubs/navigationv2Data.json:3914|5591
 			'c225ddde-d85b-11e4-ba53-00144feab7de', // server/test/stubs/navigationv2Data.json:3918|5595
 			'0f3e15c2-dc07-11e6-86ac-f253db7791c6', // server/test/stubs/navigationv2Data.json:3922|5599
-			'/circleci/project/github/RedSparr0w/node' // README.md:1
+			'/circleci/project/github/RedSparr0w/node', // README.md:1
+			'k=8d2aeb08-16bf-4429-88ff-78f0dca00004' // browser/layout/partials/fastly-insights.html
 		]
 	}
 };


### PR DESCRIPTION
Fastly will monitor and ramp this up from 10% of the traffic up to 100%.

We can turn this on/off ourselves using the `fastlyInsights` feature flag.