### PR TITLE
Add Google site verification meta tag

### DIFF
--- a/browser/layout/wrapper.html
+++ b/browser/layout/wrapper.html
@@ -86,6 +86,9 @@
 		<meta name="og:image" content="https://www.ft.com/__assets/creatives/brand-ft/icons/v3/open-graph.png">
 		<meta name="twitter:image" content="https://www.ft.com/__assets/creatives/brand-ft/icons/v3/open-graph.png">
 		{{/unless}}
+		{{#if @root.flags.googleSiteVerificationMeta}}
+		<meta name="google-site-verification" content="4-t8sFaPvpO5FH_Gnw1dkM28CQepjzo8UjjAkdDflTw" />
+		{{/if}}
 
 		{{#outputBlock 'head'}}{{/outputBlock}}
 


### PR DESCRIPTION
Added to header behind the `googleSiteVerificationMeta` flag

 🐿 v2.7.0