### PR TITLE
No backend auth in server test

### DIFF
--- a/server/test/fixtures/app/main.js
+++ b/server/test/fixtures/app/main.js
@@ -6,7 +6,8 @@ const app = module.exports = express({
 	systemCode: 'n-ui-test',
 	directory: __dirname,
 	helpers: { yell: yell },
-	layoutsDir: __dirname + '/views/'
+	layoutsDir: __dirname + '/views/',
+	withBackendAuthentication: false
 });
 
 app.get('/', function (req, res) {


### PR DESCRIPTION
Now the backend keys are in the SHARED circleci thing, they get pulled down in CI - but we don't want it for these tests.