### PR TITLE
Added "evenMoreJanky" component (behind a flag)

### DIFF
--- a/browser/js/app-initializer.js
+++ b/browser/js/app-initializer.js
@@ -3,6 +3,7 @@ import tracking from '../../components/n-ui/tracking';
 import date from 'o-date';
 import header from '../../components/n-ui/header';
 import roe from '../../components/n-ui/roe';
+import evenMoreJanky from '../../components/n-ui/evenMoreJanky';
 import oCookieMessage from 'o-cookie-message';
 import footer from 'o-footer';
 import { lazyLoad as lazyLoadImages } from 'n-image';
@@ -27,7 +28,8 @@ export const presets = {
 		cookieMessage: true,
 		ads: true,
 		syndication: true,
-		roe: true
+		roe: true,
+		evenMoreJanky: true
 	}
 };
 
@@ -153,6 +155,11 @@ export class AppInitializer {
 				if (this.enabledFeatures.roe) {
 					roe.init(flags);
 				}
+
+				if (this.enabledFeatures.evenMoreJanky) {
+					evenMoreJanky.init(flags);
+				}
+
 			});
 	}
 

--- a/browser/test/app-initializer.spec.js
+++ b/browser/test/app-initializer.spec.js
@@ -134,7 +134,8 @@ describe('AppInitializer', () => {
 				cookieMessage: true,
 				ads: true,
 				syndication: true,
-				roe: true
+				roe: true,
+				evenMoreJanky: true
 			});
 		});
 

--- a/components/n-ui/evenMoreJanky/index.js
+++ b/components/n-ui/evenMoreJanky/index.js
@@ -3,11 +3,7 @@
 // Then over time, allow them to resume their intended hight, thus creating a "janky" effect;
 // That is, the content "stutters" up/down the web page as the page layout updates.
 
-function init (flags) {
-	if (!flags || !flags.get('evenMoreJanky')) {
-		return;
-	}
-
+const addStyles = () => {
 	const styleNode = document.createElement('style');
 	styleNode.type = 'text/css';
 	const styleText = document.createTextNode(`
@@ -18,7 +14,9 @@ function init (flags) {
 	`);
 	styleNode.appendChild(styleText);
 	document.getElementsByTagName('head')[0].appendChild(styleNode);
+};
 
+const crankThatJank = () => {
 	[
 		'#o-cookie-message',
 		'#top-gpt',
@@ -31,15 +29,25 @@ function init (flags) {
 		'.article__content',
 		'.article-info',
 	]
-	.forEach(selector => {
-		document.querySelectorAll(selector).forEach(element => {
-			element.className += ' janky';
-			setTimeout(() => {
-				element.className = element.className.replace(new RegExp(/ janky/, 'g'), '');
-			},
+		.forEach(selector => {
+			document.querySelectorAll(selector).forEach(element => {
+				element.className += ' janky';
+				setTimeout(() => {
+					element.className = element.className.replace(new RegExp(/ janky/, 'g'), '');
+				},
 				Math.floor(Math.random() * 4000) + 1000);
+			});
 		});
-	});
+};
+
+function init (flags) {
+	if (!flags || !flags.get('evenMoreJanky')) {
+		return;
+	}
+	else {
+		addStyles();
+		crankThatJank();
+	}
 }
 
 module.exports = { init };

--- a/components/n-ui/evenMoreJanky/index.js
+++ b/components/n-ui/evenMoreJanky/index.js
@@ -1,0 +1,45 @@
+// For a list of elements,
+// Immediately make them arbitrarily taller than their intended height.
+// Then over time, allow them to resume their intended hight, thus creating a "janky" effect;
+// That is, the content "stutters" up/down the web page as the page layout updates.
+
+function init (flags) {
+	if (!flags || !flags.get('evenMoreJanky')) {
+		return;
+	}
+
+	const styleNode = document.createElement('style');
+	styleNode.type = 'text/css';
+	const styleText = document.createTextNode(`
+		.janky {
+				padding-top: 20px;
+				padding-bottom: 20px;
+		}
+	`);
+	styleNode.appendChild(styleText);
+	document.getElementsByTagName('head')[0].appendChild(styleNode);
+
+	[
+		'#o-cookie-message',
+		'#top-gpt',
+		'.js-markets-data',
+		'#site-navigation',
+		'#o-header-nav-desktop',
+		'#site-content',
+		'.js-track-scroll-event',
+		'.o-grid-container',
+		'.article__content',
+		'.article-info',
+	]
+	.forEach(selector => {
+		document.querySelectorAll(selector).forEach(element => {
+			element.className += ' janky';
+			setTimeout(() => {
+				element.className = element.className.replace(new RegExp(/ janky/, 'g'), '');
+			},
+				Math.floor(Math.random() * 4000) + 1000);
+		});
+	});
+}
+
+module.exports = { init };


### PR DESCRIPTION
For a list of elements,
Immediately make them arbitrarily taller than their intended height.
Then over time, allow them to resume their intended height, thus creating a "janky" effect;
That is, the content "stutters" up/down the web page as the page layout updates.