### PR TITLE
make consent available on resource locals

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,10 +59,10 @@ else
 endif
 
 test-server-plain:
-	mocha server/test/*.test.js server/test/**/*.test.js
+	mocha --file server/test/setup.js server/test/*.test.js server/test/**/*.test.js
 
 test-server-coverage: ## test-server-coverage: Run the unit tests with code coverage enabled.
-	istanbul cover node_modules/.bin/_mocha --report=$(if $(CIRCLECI),lcovonly,lcov) server/test/*.test.js server/test/**/*.test.js
+	istanbul cover node_modules/.bin/_mocha --file server/test/setup.js --report=$(if $(CIRCLECI),lcovonly,lcov) server/test/*.test.js server/test/**/*.test.js
 
 
 #

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "uglifyjs": "^2.4.11"
   },
   "dependencies": {
-    "@financial-times/n-express": "^19.8.0",
+    "@financial-times/n-express": "^19.12.0",
     "@financial-times/n-handlebars": "^1.19.4",
     "@financial-times/next-json-ld": "^0.3.0",
     "autoprefixer": "^7.2.5",

--- a/server/index.js
+++ b/server/index.js
@@ -29,7 +29,8 @@ module.exports = options => {
 		withNavigation: true,
 		withAnonMiddleware: true,
 		withCurrentYearMiddleware: true,
-		withFlags: true
+		withFlags: true,
+		withConsent: true
 	});
 
 	const {app, meta, addInitPromise} = nExpress.getAppContainer(options);

--- a/server/test/setup.js
+++ b/server/test/setup.js
@@ -1,0 +1,15 @@
+const sinon = require('sinon');
+const logger = require('@financial-times/n-logger').default;
+
+let loggerSandbox;
+
+beforeEach(() => {
+	loggerSandbox = sinon.sandbox.create();
+	[ 'info', 'warn', 'error' ].map(logLevel => {
+		loggerSandbox.stub(logger, logLevel);
+	});
+});
+
+afterEach(() => {
+	loggerSandbox.restore();
+});

--- a/server/test/setup.js
+++ b/server/test/setup.js
@@ -6,7 +6,7 @@ let loggerSandbox;
 beforeEach(() => {
 	loggerSandbox = sinon.sandbox.create();
 	[ 'info', 'warn', 'error' ].map(logLevel => {
-		loggerSandbox.stub(logger, logLevel);
+		loggerSandbox.stub(logger, logLevel).callsFake(console[logLevel]); // eslint-disable-line
 	});
 });
 


### PR DESCRIPTION
**[GDPR] Profiling**

Bumps `n-express` and forces the `withConsent` app option:
If the `FT-Consent` header is present (from preflight), parse its content into `res.locals.consent`:

```
ft-consent=marketingByemail:on,recommendedcontentOnsite:off
```

--->

```
res.locals.consent = {
 	marketingByemail: true,
 	recommendedcontentOnsite: false
}
```

See Financial-Times/next-preflight#304 for background on the `FT-Consent` header.
See https://github.com/Financial-Times/n-express/pull/500 for `n-express` changes.