### PR TITLE
Avoid two cookie consent banners

### DIFF
--- a/browser/js/app-initializer.js
+++ b/browser/js/app-initializer.js
@@ -143,8 +143,9 @@ export class AppInitializer {
 				if (this.enabledFeatures.footer) {
 					footer.init();
 				}
-
-				if (this.enabledFeatures.cookieMessage && flags.get('cookieMessage')) {
+				const bottomSlot = flags.get('messageSlotBottom');
+				const hasConsentBannerAtBottom = (bottomSlot === 'cookieConsent' || bottomSlot === 'cookieConsentA' || bottomSlot === 'cookieConsentB');
+				if (this.enabledFeatures.cookieMessage && flags.get('cookieMessage') && !hasConsentBannerAtBottom) {
 					oCookieMessage.init();
 				}
 


### PR DESCRIPTION
Add check to see if we are using the bottom slot for a cookie consent banner

 🐿 v2.8.0