### PR TITLE
Pin autoprefixer version

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "@financial-times/n-express": "^19.12.0",
     "@financial-times/n-handlebars": "^1.19.4",
     "@financial-times/next-json-ld": "^0.3.0",
-    "autoprefixer": "^8.0.0",
+    "autoprefixer": "8.6.0",
     "aws-sdk": "^2.190.0",
     "babel-core": "^6.26.0",
     "babel-loader": "^7.1.2",


### PR DESCRIPTION
https://github.com/postcss/autoprefixer/issues/1048 broke the article build with
[1] TypeError: Cannot read property 'type' of undefined
[1]     at /home/ubuntu/next-article/node_modules/@financial-times/n-ui/node_modules/autoprefixer/lib/hacks/grid-utils.js:348:25