### PR TITLE
Suffix page titles with 'Financial Times'

### DIFF
--- a/browser/layout/vanilla.html
+++ b/browser/layout/vanilla.html
@@ -3,7 +3,7 @@
 	<head>
 		<meta charset="utf-8">
 		<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
-		<title>{{#title}}{{{this}}}{{/title}}</title>
+		<title>{{#title}}{{{this}}} | {{/title}}Financial Times</title>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
 		<meta name="theme-color" content="#fff1e5">
 		<style>html{background-color:#fff1e5;}</style>

--- a/browser/layout/wrapper.html
+++ b/browser/layout/wrapper.html
@@ -3,7 +3,7 @@
 	<head>
 		<meta charset="utf-8">
 		<meta http-equiv="X-UA-Compatible" content="IE=edge">
-		<title>{{#title}}{{{this}}}{{/title}}</title>
+		<title>{{#title}}{{{this}}} | {{/title}}Financial Times</title>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
 		<meta name="theme-color" content="#333333">
 		<style>html{background-color:#fff1e5;}</style>


### PR DESCRIPTION
The advice for both [accessibility](https://www.w3.org/TR/WCAG20-TECHS/G88.html) and [SEO](https://support.google.com/webmasters/answer/35624?hl=en) is it can be beneficial to suffix the page title with the brand.

- it will give a screenreader user more context when cycling through browser tabs
- it gives all users a better default when bookmarking a page

It's possible that Google could continue to automatically suffix our search results with ' - Financial Times' for a period after this change is put live, so we could request a re-index to update that, and if that doesn't fix it, contact them via [webmaster help forum](https://productforums.google.com/forum/#!forum/webmasters)

 🐿 v2.8.0