### PR TITLE
Update mainFields in webpack

### DIFF
--- a/build/webpack/common.js
+++ b/build/webpack/common.js
@@ -46,7 +46,7 @@ module.exports = {
 
 		// package.json / bower.json
 		// fields for package resolution
-		mainFields: ['main', 'browser'],
+		mainFields: ['browser', 'main'],
 
 		// package.json / bower.json
 		// fields for aliasing


### PR DESCRIPTION
# Update mainFields in webpack common config
## What
- Update `mainFields` in webpack common config to prefer `browser` over `main`

## Why
- If a file has already been made for the browser, we should use that rather than doing the work again
- Without this we cannot use x-engine with n-ui