### PR TITLE
Replace Googles document.write with async version

### DIFF
--- a/browser/layout/wrapper.html
+++ b/browser/layout/wrapper.html
@@ -102,18 +102,20 @@
 	<body data-next-is-logged-in="{{@root.anon.userIsLoggedIn}}" data-trackable="page:{{@root.__name}}{{#if @root.trackablePageName}}/{{@root.trackablePageName}}{{/if}}">
 		{{#if withGcs}}
 			<script type="text/javascript">
-				(function() {
-					var ARTICLE_URL = window.location.href;
-					var CONTENT_ID = 'everything';
-					document.write(
-						'<scr' + 'ipt ' +
-						'src="//survey.g.doubleclick.net/survey?site=_ykzfqallocklxfmrw3y6sankbe' +
-						'&amp;url=' + encodeURIComponent(ARTICLE_URL) +
-						(CONTENT_ID ? '&amp;cid=' + encodeURIComponent(CONTENT_ID) : '') +
-						'&amp;random=' + (new Date).getTime() +
-						'" type="text/javascript">' + '\x3C/scr' + 'ipt>'
-					);
-				})();
+				var triggerGoogleCustomerSurvey = function(articleUrl, contentId) {
+					var ARTICLE_URL = articleUrl;
+					var CONTENT_ID = contentId || '';
+					var el = document.createElement('script');
+					var url = 'http://survey.g.doubleclick.net/survey?site=_ykzfqallocklxfmrw3y6sankbe' +
+						'&url=' + encodeURIComponent(ARTICLE_URL) +
+						(CONTENT_ID ? '&cid=' + encodeURIComponent(CONTENT_ID) : '') +
+						'&random=' + (new Date).getTime() +
+						'&after=1';
+						el.setAttribute('src', url);
+						var head = document.getElementsByTagName('head')[0] ||
+						document.getElementsByTagName('body')[0];
+						head.appendChild(el);
+				};
 			</script>
 		{{/if}}
 


### PR DESCRIPTION
This used to add Google customer surveys on article pages. This is a
newer version of the code provided by Google so we don't have to do
horrible `document.write`'s

These surveys are currently impossible to force onto the page so
changing this is very much fire and forget. Yay.

 🐿 v2.10.2