### PR TITLE
Add enhanced-resolve^3.4.1 as a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "colors": "^1.3.0",
     "commander": "^2.15.1",
     "concurrently": "^3.6.0",
+    "enhanced-resolve": "^3.4.1",
     "focus-visible": "^4.1.4",
     "fs-extra": "^6.0.1",
     "ft-poller": "^3.0.1",


### PR DESCRIPTION
`bower-resolve-webpack-plugin@1.0.5` requires a peer of `enhanced-resolve@^3.1.0`

We can change this to `^4.0.0` when this patch for `bower-resolve-webpack-plugin` is released: https://github.com/codewizz/bower-resolve-webpack-plugin/pull/5