### PR TITLE
Fix CircleCI 2.0 publish job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -116,8 +116,8 @@ jobs:
           name: shared-helper / npm-store-auth-token
           command: .circleci/shared-helpers/helper-npm-store-auth-token
       - run:
-          name: shared-helper / npm-version-and-publish-public
-          command: .circleci/shared-helpers/helper-npm-version-and-publish-public
+          name: Publish and deploy n-ui
+          command: make deploy
 
 workflows:
 


### PR DESCRIPTION
`n-ui` does a few other things when publishing so we need to call `make deploy`.

 🐿 v2.10.2