### PR TITLE
Fix call to `nht deploy-hashed-assets` in `publish` job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,11 +77,8 @@ jobs:
           name: shared-helper / npm-install-peer-deps
           command: .circleci/shared-helpers/helper-npm-install-peer-deps
       - run:
-          name: Run the project build task
-          command: make build
-      - run:
-          name: Run the project build-production task
-          command: make build-production
+          name: Run the project build-dist task
+          command: make build-dist
       - run:
           name: shared-helper / generate-build-state-artifacts
           command: .circleci/shared-helpers/helper-generate-build-state-artifacts

--- a/Makefile
+++ b/Makefile
@@ -115,7 +115,7 @@ a11y: test-build pally-conf
 # Note: `run` executes `node demo/app`, which fires up express, then deploys
 # a test static site to s3, then exits, freeing the process to execute `smoke a11y`.
 test:
-	make developer-note verify pally-conf test-server test-browser test-build run smoke a11y build-dist
+	make developer-note verify pally-conf test-server test-browser test-build run smoke a11y
 	bundlesize
 
 build-production: build-bundle


### PR DESCRIPTION
We need to run `make build-dist` in the `build` job to generate the `assets-hashes.json` file required by
`nht deploy-hashed-assets` in the `publish` job. This is because the `test` job, where `make test` previously triggered `make build-dist`, does not persist any changes in the working directory to the workspace that is shared between jobs - `build` is the only job that does persist changes to the workspace.

 🐿 v2.10.2