### PR TITLE
add brandmetrics survey

### DIFF
--- a/browser/layout/wrapper.html
+++ b/browser/layout/wrapper.html
@@ -98,6 +98,7 @@
 		{{#if @root.flags.moatAdsTraffic}}
 			<script async id="moat-ivt" src="https://sejs.moatads.com/financialtimesprebidheader859796398452/yi.js"></script>
 		{{/if}}
+		<script async src="https://cdn.brandmetrics.com/survey/script/45b903c6675b4a9b85db13385a3d6084.js"></script>
 	</head>
 	<body data-next-is-logged-in="{{@root.anon.userIsLoggedIn}}" data-trackable="page:{{@root.__name}}{{#if @root.trackablePageName}}/{{@root.trackablePageName}}{{/if}}">
 		{{#if withGcs}}
@@ -147,5 +148,6 @@
 	{{#if @root.flags.fastlyInsights}}
 		{{>layout/partials/fastly-insights}}
 	{{/if}}
+	{{>n-ui/brandmetrics/template}}
 	</body>
 </html>

--- a/browser/layout/wrapper.html
+++ b/browser/layout/wrapper.html
@@ -98,7 +98,9 @@
 		{{#if @root.flags.moatAdsTraffic}}
 			<script async id="moat-ivt" src="https://sejs.moatads.com/financialtimesprebidheader859796398452/yi.js"></script>
 		{{/if}}
-		<script async src="https://cdn.brandmetrics.com/survey/script/45b903c6675b4a9b85db13385a3d6084.js"></script>
+		{{#if @root.flags.adsInizioSurvey}}
+			<script async src="https://cdn.brandmetrics.com/survey/script/45b903c6675b4a9b85db13385a3d6084.js"></script>
+		{{/if}}
 	</head>
 	<body data-next-is-logged-in="{{@root.anon.userIsLoggedIn}}" data-trackable="page:{{@root.__name}}{{#if @root.trackablePageName}}/{{@root.trackablePageName}}{{/if}}">
 		{{#if withGcs}}
@@ -148,6 +150,8 @@
 	{{#if @root.flags.fastlyInsights}}
 		{{>layout/partials/fastly-insights}}
 	{{/if}}
-	{{>n-ui/brandmetrics/template}}
+	{{#if @root.flags.adsInizioSurvey}}
+		{{>n-ui/brandmetrics/template}}
+	{{/if}}
 	</body>
 </html>

--- a/components/n-ui/brandmetrics/main.scss
+++ b/components/n-ui/brandmetrics/main.scss
@@ -1,0 +1,13 @@
+.brandmetrics-survey {
+	display: none;
+	@include oGridRespondTo('M') {
+		display: block;
+	}
+	position: fixed;
+	right: 0%;
+	bottom: 50px;
+	z-index: 1000;
+	margin-right: -10px;
+	max-width: 300px;
+	max-height: 330px;
+}

--- a/components/n-ui/brandmetrics/main.scss
+++ b/components/n-ui/brandmetrics/main.scss
@@ -9,5 +9,4 @@
 	z-index: 1000;
 	margin-right: -10px;
 	max-width: 300px;
-	max-height: 330px;
 }

--- a/components/n-ui/brandmetrics/template.html
+++ b/components/n-ui/brandmetrics/template.html
@@ -1,0 +1,8 @@
+<div id="brandmetrics-survey" class="brandmetrics-survey">
+	<script>
+		window._brandmetrics = window._brandmetrics || [];
+		window._brandmetrics.push(
+			{ cmd: "_loadsurvey" }
+		);
+	</script>
+</div>

--- a/main.scss
+++ b/main.scss
@@ -17,3 +17,5 @@ $n-ui-foundations-applied: true;
 
 @import 'components/n-ui/perf-janky/calm-timestamp';
 @import 'components/n-ui/perf-janky/calm-ad';
+
+@import 'components/n-ui/brandmetrics/main';


### PR DESCRIPTION
 🐿 v2.10.2

Brandmetrics is a company that pops up a survey on our site to ask people annoying questions about the ads they've seen. This was initially loaded from DFP, and it was served as an ad, meaning we had no contrlol. This brings it in house (slightly), so he know where it lives and can make sure that the survey doesn't break out of its iframe or cause users issues on mobile.
