### PR TITLE
fix case where slots can be undefined when initalising o-ads

### DIFF
--- a/components/n-ui/ads/index.js
+++ b/components/n-ui/ads/index.js
@@ -43,6 +43,12 @@ function initOAds (flags, appName, adOptions) {
 		const containers = [].slice.call(document.querySelectorAll('.o-ads'));
 		slotCount = containers.length;
 		utils.log.info(slotCount + ' ad slots found on page');
+
+		if (!res) {
+			// TODO: Investigate why res.slots can be empty
+			return;
+		}
+
 		containers.forEach(res.slots.initSlot.bind(res.slots));
 	});
 }


### PR DESCRIPTION
 🐿 v2.10.3

It's causing a lot of errors to be logged to sentry. 

Quick fix for now, creating a card to keep track of it
https://trello.com/c/ZiVtoQP7/325-slots-can-be-undefined-when-initalising-o-ads-in-n-ui-investigate-why