### PR TITLE
[DO NOT MERGE] Remove haikro from CLI command

### DIFF
--- a/build/app/cli.js
+++ b/build/app/cli.js
@@ -82,11 +82,6 @@ program
 			.then(() => options.production && assetHashes())
 			.then(aboutJson)
 			.then(grabNUiAssets)
-			.then(() => {
-				if (options.production && fs.existsSync(path.join(process.cwd(), 'Procfile'))) {
-					return shellpipe('haikro build');
-				}
-			})
 			.catch(exit);
 	});
 


### PR DESCRIPTION
Removing this for testing out with next-heroku-playground

(incidentally NO idea why n-ui build needs to call haikro build. They should be independent.)