### PR TITLE
Add the rootid as an oAdsConfig param

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -22,7 +22,7 @@
     "n-topic-search": "^1.0.3",
     "n-ui-foundations": "^3.0.2",
     "next-session-client": "^2.3.4",
-    "o-ads": "^10.0.0",
+    "o-ads": "^10.1.2",
     "o-errors": "^3.6.1",
     "o-expander": "^4.4.4",
     "o-footer": "^6.0.10",

--- a/components/n-ui/ads/js/oAdsConfig.js
+++ b/components/n-ui/ads/js/oAdsConfig.js
@@ -11,7 +11,8 @@ module.exports = function (flags, appName, adOptions) {
 	const targetingOptions = {
 		pt: appName.toLowerCase().substr(0, 3),
 		nlayout: utils.getLayoutName(),
-		mvt: utils.getABTestState()
+		mvt: utils.getABTestState(),
+		rootid: oTrackingCore.getRootID()
 	};
 
 	if (flags.get('adsEnableTestCreatives')) {
@@ -31,7 +32,9 @@ module.exports = function (flags, appName, adOptions) {
 		id: 'KHUSeE3x',
 		attributes: {
 			user: {},
-			page: {}
+			page: {
+				rootid: oTrackingCore.getRootID()
+			}
 		}
 	};
 
@@ -125,7 +128,6 @@ module.exports = function (flags, appName, adOptions) {
 			page: getContextualTargeting(appName),
 			usePageZone: true
 		},
-		rootid: oTrackingCore.getRootID(),
 		disableConsentCookie: flags.get('adsDisableCookieConsent'),
 		validateAdsTraffic: flags.get('moatAdsTraffic')
 	};

--- a/components/n-ui/ads/js/oAdsConfig.js
+++ b/components/n-ui/ads/js/oAdsConfig.js
@@ -1,5 +1,6 @@
 const utils = require('./utils');
 const sandbox = require('./sandbox');
+const oTrackingCore = require('o-tracking/src/javascript/core.js');
 const extend = require('o-ads').utils.extend;
 const apiUrlRoot = 'https://ads-api.ft.com/v1/';
 
@@ -124,8 +125,8 @@ module.exports = function (flags, appName, adOptions) {
 			page: getContextualTargeting(appName),
 			usePageZone: true
 		},
+		rootid: oTrackingCore.getRootID(),
 		disableConsentCookie: flags.get('adsDisableCookieConsent'),
 		validateAdsTraffic: flags.get('moatAdsTraffic')
 	};
-
 };

--- a/components/n-ui/ads/test/oAdsConfig.spec.js
+++ b/components/n-ui/ads/test/oAdsConfig.spec.js
@@ -2,7 +2,6 @@
 const utils = require('../js/utils');
 const oAdsConfig = require('../js/oAdsConfig');
 const adsSandbox = require('../js/sandbox');
-const oTrackingCore = require('o-tracking/src/javascript/core.js');
 const fakeArticleUuid = '123456';
 const fakeConceptUuid = '12345678';
 
@@ -158,13 +157,6 @@ describe('Config', () => {
 	});
 
 	describe('o-ads', () => {
-
-		it('should pass rootId parameter', () => {
-			const flags = { get: () => true };
-			const config = oAdsConfig(flags, 'article');
-			expect(config.rootid).to.equal(oTrackingCore.getRootID());
-		});
-
 		it('Should pass the correct url to o-ads fetch', () => {
 			const flags = { get: () => true };
 			const config = oAdsConfig(flags, 'article' );

--- a/components/n-ui/ads/test/oAdsConfig.spec.js
+++ b/components/n-ui/ads/test/oAdsConfig.spec.js
@@ -2,6 +2,7 @@
 const utils = require('../js/utils');
 const oAdsConfig = require('../js/oAdsConfig');
 const adsSandbox = require('../js/sandbox');
+const oTrackingCore = require('o-tracking/src/javascript/core.js');
 const fakeArticleUuid = '123456';
 const fakeConceptUuid = '12345678';
 
@@ -157,6 +158,12 @@ describe('Config', () => {
 	});
 
 	describe('o-ads', () => {
+
+		it('should pass rootId parameter', () => {
+			const flags = { get: () => true };
+			const config = oAdsConfig(flags, 'article');
+			expect(config.rootid).to.equal(oTrackingCore.getRootID());
+		});
 
 		it('Should pass the correct url to o-ads fetch', () => {
 			const flags = { get: () => true };


### PR DESCRIPTION
 🐿 v2.10.2

This was previously set in o-ads directly by importing o-tracking. As o-ads is used across many websites, and the rootid is only used on ft.com, we want to abstract this into n-ui and pass this as a config parameter