### PR TITLE
Add option for no haikro to Cli command

### DIFF
--- a/build/app/cli.js
+++ b/build/app/cli.js
@@ -83,7 +83,7 @@ program
 			.then(aboutJson)
 			.then(grabNUiAssets)
 			.then(() => {
-				if (options.production && fs.existsSync(path.join(process.cwd(), 'Procfile'))) {
+				if (options.production && fs.existsSync(path.join(process.cwd(), 'Procfile')) && !process.env.NO_HAIKRO) {
 					return shellpipe('haikro build');
 				}
 			})


### PR DESCRIPTION
Checks that the env var NO_HAIKRO does not exist in order to run Haikro build. This is so we can build without Haikro while testing out the new build and deployment process in next-heroku-playground and next-search-page.

@adgad is this ok?

