### PR TITLE
Add support for implicit '.jsx' imports

### DIFF
--- a/build/webpack/common.js
+++ b/build/webpack/common.js
@@ -41,6 +41,11 @@ module.exports = {
 		// paths are looked up directly the order is respected
 		modules: ['bower_components', 'node_modules'],
 
+		// Automatically resolve certain extensions. This defaults to: ['.wasm', '.mjs', '.js', '.json']
+		extensions: [
+			'.wasm', '.mjs', '.js', '.json', '.jsx'
+		],
+
 		// package description files
 		descriptionFiles: ['bower.json', 'package.json'],
 


### PR DESCRIPTION
# Add support for implicit `.jsx` imports

## What
- Enables importing of `.jsx` files without the necessity of specifying the file extension in the import statement.

## How
- Adds `.jsx` to `resolve.extensions` in the n-ui webpack config, [see the docs](https://webpack.js.org/configuration/resolve/#resolve-extensions) for more info. 

## Why
- Makes life easier for developers, for example it enables the use of `.jsx` mainFiles, i.e. `/super-cool-thing/index.jsx` can be imported like-so:

```jsx
import xEngine from '@financial-times/x-engine'
import SuperCoolThing from './super-cool-thing'

const superCoolThingEl = document.querySelector('.js-super-cool-thing');

xEngine.render(superCoolThingEl, <SuperCoolThing isFabulous={true}/>
```

## Checks
- [x] 🐿 v2.10.0