### PR TITLE
Add metricName for error statii

### DIFF
--- a/components/n-ui/tracking/ft/index.js
+++ b/components/n-ui/tracking/ft/index.js
@@ -67,6 +67,8 @@ const oTrackingWrapper = {
 				context.url = pageViewConf.context.url = window.parent.location.toString();
 				context.referrer = pageViewConf.context.referrer = window.parent.document.referrer;
 				context.errorStatus = pageViewConf.context.errorStatus = errorStatus;
+				
+				context.metricName = `page-error.${context.app}.${errorStatus}`;
 
 				if (errorReason) {
 					context.errorReason = pageViewConf.context.errorReason = errorReason;

--- a/components/n-ui/tracking/ft/index.js
+++ b/components/n-ui/tracking/ft/index.js
@@ -67,7 +67,7 @@ const oTrackingWrapper = {
 				context.url = pageViewConf.context.url = window.parent.location.toString();
 				context.referrer = pageViewConf.context.referrer = window.parent.document.referrer;
 				context.errorStatus = pageViewConf.context.errorStatus = errorStatus;
-				
+
 				context.metricName = `page-error.${context.app}.${errorStatus}`;
 
 				if (errorReason) {


### PR DESCRIPTION
This PR in conjunction with https://github.com/Financial-Times/spoor-consumer/pull/192/ will allow us to claw back _some_ of the functionality of the QA dashboard on beacon.

Or at least let us track and alert on the number of errors our users are seeing.