### PR TITLE
Check if app.json exists when deciding whether to run Haikro

### DIFF
--- a/build/app/cli.js
+++ b/build/app/cli.js
@@ -93,7 +93,7 @@ program
 			.then(aboutJson)
 			.then(grabNUiAssets)
 			.then(() => {
-				if (options.production && fs.existsSync(path.join(process.cwd(), 'Procfile')) && !process.env.NO_HAIKRO) {
+				if (options.production && fs.existsSync(path.join(process.cwd(), 'Procfile')) && !fs.existsSync(path.join(process.cwd(), 'app.json'))) {
 					return shellpipe('haikro build');
 				}
 			})


### PR DESCRIPTION
 🐿 v2.11.0

Apps that have migrated to the new Heroku deployment process don't use Haikro. We were checking for an env var `NO_HAIKRO` but to avoid having to add this to every app, this PR changes this to check for an app.json file instead. It _should_ be the case that only post-migration apps will have one of these.