### PR TITLE
Support multiple teaser tests

### DIFF
--- a/components/n-ui/tracking/ft/index.js
+++ b/components/n-ui/tracking/ft/index.js
@@ -122,8 +122,6 @@ const oTrackingWrapper = {
 				useSendBeacon: flags.get('sendBeacon')
 			});
 
-			alert('1 hello. in tracking index.js, about to set page context with headline testing info ');
-
 			//headline testing, add variant to the page view event as long as there is only one article under test
 			if (location.pathname === '/') {
 				const alternativeHeadlines = [].slice.call(document.querySelectorAll('[data-trackable-context-headline-variant]'));
@@ -134,11 +132,10 @@ const oTrackingWrapper = {
 					pageViewConf.context['headline-uuid'] = articleUuid;
 				}
 			}
-			//teaser testing (supersedes 'headline' testing). Add extra page context info related to the relevant teasers under test.
+
+			//teaser-testing (supersedes 'headline' testing). Add extra page context info related to the relevant teasers under test.
 			if (location.pathname === '/') {
-				const teasersUnderTest = [].slice.call(document.querySelectorAll('[data-trackable-context-teaser-variant]'));
-				const transformedTeasers = abTestHelpers.getTeaserTestContext(teasersUnderTest);
-				pageViewConf.context['teaser-testing'] = transformedTeasers;
+				pageViewConf.context['teaser_tests'] = abTestHelpers.getTeaserTestContext(document);
 			}
 
 			// barriers

--- a/components/n-ui/tracking/ft/index.js
+++ b/components/n-ui/tracking/ft/index.js
@@ -2,6 +2,7 @@ const oTracking = require('o-tracking');
 const oGrid = require('o-grid');
 const oViewport = require('o-viewport');
 const nextEvents = require('./next-events');
+const abTestHelpers = require('./utils/abTestHelpers');
 
 
 import {broadcast} from 'n-ui-foundations';
@@ -121,6 +122,8 @@ const oTrackingWrapper = {
 				useSendBeacon: flags.get('sendBeacon')
 			});
 
+			alert('1 hello. in tracking index.js, about to set page context with headline testing info ');
+
 			//headline testing, add variant to the page view event as long as there is only one article under test
 			if (location.pathname === '/') {
 				const alternativeHeadlines = [].slice.call(document.querySelectorAll('[data-trackable-context-headline-variant]'));
@@ -130,6 +133,12 @@ const oTrackingWrapper = {
 					const articleUuid = alternativeHeadlines[0].getAttribute('href').replace('/content/', '');
 					pageViewConf.context['headline-uuid'] = articleUuid;
 				}
+			}
+			//teaser testing (supersedes 'headline' testing). Add extra page context info related to the relevant teasers under test.
+			if (location.pathname === '/') {
+				const teasersUnderTest = [].slice.call(document.querySelectorAll('[data-trackable-context-teaser-variant]'));
+				const transformedTeasers = abTestHelpers.getTeaserTestContext(teasersUnderTest);
+				pageViewConf.context['teaser-testing'] = transformedTeasers;
 			}
 
 			// barriers

--- a/components/n-ui/tracking/ft/utils/abTestHelpers.js
+++ b/components/n-ui/tracking/ft/utils/abTestHelpers.js
@@ -11,6 +11,8 @@ const getTeaserTestContext = function (teasersUnderTest) {
 		Object.assign({}, {contentId: element.getAttribute('data-content-id'), variant: element.getAttribute('data-trackable-context-teaser-variant') } );
 	} );
 
+	console.log('transformed teasers = ' + JSON.stringify(transformedTeasers));
+
 	return {hello: 'roland'};
 
 };

--- a/components/n-ui/tracking/ft/utils/abTestHelpers.js
+++ b/components/n-ui/tracking/ft/utils/abTestHelpers.js
@@ -1,20 +1,18 @@
 
-const getTeaserTestContext = function (teasersUnderTest) {
+const getTeaserTestContext = function (doc) {
 
-	for (i=0; i<teasersUnderTest.length; i++) {
-	  alert(i);
+	const teasersUnderTest = [].slice.call(doc.querySelectorAll('[data-trackable-context-teaser-variant]'));
+	var transformedTeasers = [];
+	for (var i=0; i<teasersUnderTest.length; i++) {
+	  transformedTeasers.push(
+		{
+			content_id: teasersUnderTest[i].getAttribute('data-content-id'),
+			variant: teasersUnderTest[i].getAttribute('data-trackable-context-teaser-variant'),
+			headline_text: teasersUnderTest[i].innerText
+		} 
+	  );
 	}
-
-		// todo go through each one and get the contentid, the variant name and (optionally, the variant text).
-	// todo include the actual headline text
-	const transformedTeasers = teasersUnderTest.map( (element, index, array) => { 
-		Object.assign({}, {contentId: element.getAttribute('data-content-id'), variant: element.getAttribute('data-trackable-context-teaser-variant') } );
-	} );
-
-	console.log('transformed teasers = ' + JSON.stringify(transformedTeasers));
-
-	return {hello: 'roland'};
-
+	return transformedTeasers;
 };
 
-module.exports = getTeaserTestContext;
+module.exports.getTeaserTestContext = getTeaserTestContext;

--- a/components/n-ui/tracking/ft/utils/abTestHelpers.js
+++ b/components/n-ui/tracking/ft/utils/abTestHelpers.js
@@ -1,0 +1,18 @@
+
+const getTeaserTestContext = function (teasersUnderTest) {
+
+	for (i=0; i<teasersUnderTest.length; i++) {
+	  alert(i);
+	}
+
+		// todo go through each one and get the contentid, the variant name and (optionally, the variant text).
+	// todo include the actual headline text
+	const transformedTeasers = teasersUnderTest.map( (element, index, array) => { 
+		Object.assign({}, {contentId: element.getAttribute('data-content-id'), variant: element.getAttribute('data-trackable-context-teaser-variant') } );
+	} );
+
+	return {hello: 'roland'};
+
+};
+
+module.exports = getTeaserTestContext;

--- a/components/n-ui/tracking/ft/utils/abTestHelpers.js
+++ b/components/n-ui/tracking/ft/utils/abTestHelpers.js
@@ -2,16 +2,15 @@
 const getTeaserTestContext = function (doc) {
 
 	const teasersUnderTest = [].slice.call(doc.querySelectorAll('[data-trackable-context-teaser-variant]'));
-	var transformedTeasers = [];
-	for (var i=0; i<teasersUnderTest.length; i++) {
-	  transformedTeasers.push(
-		{
-			content_id: teasersUnderTest[i].getAttribute('data-content-id'),
-			variant: teasersUnderTest[i].getAttribute('data-trackable-context-teaser-variant'),
-			headline_text: teasersUnderTest[i].innerText
-		} 
-	  );
-	}
+
+	const transformedTeasers = teasersUnderTest.map(teaser => 
+     ({
+				content_id: teaser.getAttribute('data-content-id'),
+				variant: teaser.getAttribute('data-trackable-context-teaser-variant'),
+				headline_text: teaser.innerText
+    })
+	);
+
 	return transformedTeasers;
 };
 

--- a/components/n-ui/tracking/ft/utils/abTestHelpers.js
+++ b/components/n-ui/tracking/ft/utils/abTestHelpers.js
@@ -4,11 +4,11 @@ const getTeaserTestContext = function (doc) {
 	const teasersUnderTest = [].slice.call(doc.querySelectorAll('[data-trackable-context-teaser-variant]'));
 
 	const transformedTeasers = teasersUnderTest.map(teaser => 
-     ({
-				content_id: teaser.getAttribute('data-content-id'),
-				variant: teaser.getAttribute('data-trackable-context-teaser-variant'),
-				headline_text: teaser.innerText
-    })
+		({
+			content_id: teaser.getAttribute('data-content-id'),
+			variant: teaser.getAttribute('data-trackable-context-teaser-variant'),
+			headline_text: teaser.innerText
+		})
 	);
 
 	return transformedTeasers;

--- a/components/n-ui/tracking/test/ft/utils/abTestHelpers.spec.js
+++ b/components/n-ui/tracking/test/ft/utils/abTestHelpers.spec.js
@@ -1,0 +1,48 @@
+/*global describe, it, expect, beforeEach, afterEach*/
+/*jshint expr: true */
+const abTestHelpers = require('../../../ft/utils/abTestHelpers');
+
+describe('abTestHelpers', function () {
+
+	const div = document.createElement('div');
+	document.body.appendChild(div);
+
+	div.innerHTML += `
+	<div class="o-teaser__heading js-teaser-heading">
+		<a 	href="/content/00000000-0000-0000-0000-111111111111"
+			class="js-teaser-heading-link"
+			data-content-id="00000000-0000-0000-0000-111111111111"
+			data-trackable="main-link"							
+			data-trackable-context-headline-variant="variant1"
+			data-trackable-context-teaser-variant="variant77"
+		>
+			Greece racks up surplus by keeping foot on brake
+		</a>
+	</div>
+	<div class="o-teaser__heading js-teaser-heading">
+	<a 	href="/content/00000000-0000-0000-0000-222222222222"
+		class="js-teaser-heading-link"
+		data-content-id="00000000-0000-0000-0000-222222222222"
+		data-trackable="main-link"							
+		data-trackable-context-headline-variant="variant2"
+		data-trackable-context-teaser-variant="variant4"
+	>
+		A second teaser headline
+</a>
+</div>
+`;
+
+	it('correctly converts teaser html into json metadata', function () {
+
+		const expectedContexts = [
+			{content_id: '00000000-0000-0000-0000-111111111111', variant: 'variant77', headline_text: 'Greece racks up surplus by keeping foot on brake'},
+			{content_id: '00000000-0000-0000-0000-222222222222', variant: 'variant4', headline_text: 'A second teaser headline'}
+		];
+		const teaserContextInfo = abTestHelpers.getTeaserTestContext(document);
+			
+		expect(teaserContextInfo.length).to.equal(2);
+		expect(teaserContextInfo[0]).to.deep.equal(expectedContexts[0]);
+		expect(teaserContextInfo[1]).to.deep.equal(expectedContexts[1]);
+	});
+
+});

--- a/components/n-ui/tracking/test/ft/utils/abTestHelpers.spec.js
+++ b/components/n-ui/tracking/test/ft/utils/abTestHelpers.spec.js
@@ -15,9 +15,7 @@ describe('abTestHelpers', function () {
 			data-trackable="main-link"							
 			data-trackable-context-headline-variant="variant1"
 			data-trackable-context-teaser-variant="variant77"
-		>
-			Greece racks up surplus by keeping foot on brake
-		</a>
+		>Greece racks up surplus by keeping foot on brake</a>
 	</div>
 	<div class="o-teaser__heading js-teaser-heading">
 	<a 	href="/content/00000000-0000-0000-0000-222222222222"
@@ -26,9 +24,7 @@ describe('abTestHelpers', function () {
 		data-trackable="main-link"							
 		data-trackable-context-headline-variant="variant2"
 		data-trackable-context-teaser-variant="variant4"
-	>
-		A second teaser headline
-</a>
+	>A second teaser headline</a>
 </div>
 `;
 

--- a/demo/views/default.html
+++ b/demo/views/default.html
@@ -1,8 +1,30 @@
 <div id="site-content">
 	<p>{{@root.latestNUiVersions}}</p>
 	<p>lorem ipsum dolor sit down and listen to some latin</p>
+	<div class="o-teaser__heading js-teaser-heading">
+		<a 	href="/content/00000000-0000-0000-0000-111111111111"
+			class="js-teaser-heading-link"
+			data-content-id="00000000-0000-0000-0000-111111111111"
+			data-trackable="main-link"							
+			data-trackable-context-headline-variant="variant1"
+			data-trackable-context-teaser-variant="variant3"
+			>
+				Greece racks up surplus by keeping foot on brake
+		</a>
+	</div>
 	<p>lorem ipsum dolor sit down and listen to some latin</p>
 	<p>lorem ipsum dolor sit down and listen to some latin</p>
+	<div class="o-teaser__heading js-teaser-heading">
+		<a 	href="/content/00000000-0000-0000-0000-222222222222"
+			class="js-teaser-heading-link"
+			data-content-id="00000000-0000-0000-0000-222222222222"
+			data-trackable="main-link"							
+			data-trackable-context-headline-variant="variant1"
+			data-trackable-context-teaser-variant="variant4"
+			>
+				Some varinat headline innit
+		</a>
+	</div>
 	<p>lorem ipsum dolor sit down and listen to some latin</p>
 	<p>lorem ipsum dolor sit down and listen to some latin</p>
 	<p>lorem ipsum dolor sit down and listen to some latin</p>


### PR DESCRIPTION
This is intended to replace the 'headline testing' code that currently supports A/B testing of only one homepage teaser at any given time.  Will rip out the headline testing code once its replacement, teaser-testing, is fully operational end-to-end.