### PR TITLE
Improve error handling for navigation api

### DIFF
--- a/server/models/navigation/navigationModelV2.js
+++ b/server/models/navigation/navigationModelV2.js
@@ -138,7 +138,11 @@ module.exports = class NavigationModelV2 {
 				})
 				.catch(e => {
 					if(e.event){
-						log.error(e);
+						if (e.status === 404) {
+							log.debug(e); // No need to log 404 as an error, as it might spam the logs
+						} else {
+							log.error(e);
+						}						
 					}else{
 						log.error({event:'NAVIGATION_HIERARCHY_ERROR', error:e.message});
 					}


### PR DESCRIPTION
## What was done
Log a debug log if the event status is 404.

## Why
Reduces number of logs, making meaningful errors more visible in the log stream.