### PR TITLE
add polyfill for 'String.prototype.padStart'

### DIFF
--- a/server/lib/asset-manager/polyfill-io.js
+++ b/server/lib/asset-manager/polyfill-io.js
@@ -31,7 +31,8 @@ const queryStrings = {
 			'Array.prototype.@@iterator',
 			'EventSource',
 			'Number.isInteger',
-			'Object.entries'
+			'Object.entries',
+			'String.prototype.padStart'
 		],
 		flags: 'gated'
 	}),


### PR DESCRIPTION
This adds the polyfill for `String.prototype.padStart`, the myft timeline view uses this function [here](https://github.com/Financial-Times/next-myft-page/commit/a8ce65a1238505321806143f5069cdd6522f8445#diff-b207b4f846e64ad21de46c9bdc61f373R15) and it throws an error in IE11.

This will likely address all these [errors in Sentry](https://sentry.io/nextftcom/ft-next-myft-page/?query=is%3Aunresolved+padStart)

<img width="1508" alt="screen shot 2019-01-25 at 10 21 33" src="https://user-images.githubusercontent.com/11544418/51740198-4283fd00-208b-11e9-98a6-e9bf6fb2c0b1.png">
