### PR TITLE
Upgrade o-ads to 10.2.2

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -22,7 +22,7 @@
     "n-topic-search": "^1.0.3",
     "n-ui-foundations": "^3.0.2",
     "next-session-client": "^2.3.4",
-    "o-ads": "^10.2.1",
+    "o-ads": "^10.2.2",
     "o-errors": "^3.6.1",
     "o-expander": "^4.4.4",
     "o-footer": "^6.0.10",


### PR DESCRIPTION
`o-ads` v10.2.2 corrects the version reported by `oAds.getVersion()`.

 🐿 v2.12.0