### PR TITLE
Add audio teaser view tracking

### DIFF
--- a/components/n-ui/tracking/ft/events/audio-teaser-view.js
+++ b/components/n-ui/tracking/ft/events/audio-teaser-view.js
@@ -1,0 +1,22 @@
+const oTracking = require('o-tracking');
+
+const audioTeaserView = {
+	init: () => {
+		const getContentIdFromXTeaser = el => el.getAttribute('data-id');
+		const getContentIdFromNTeaser = el => el.querySelector('.o-teaser__heading a').getAttribute('data-content-id');
+
+		oTracking.view.init({
+			selector: '.o-teaser--audio',
+			getContextData: (el) => {
+				return {
+					contentId: getContentIdFromXTeaser(el) || getContentIdFromNTeaser(el),
+					component: 'teaser',
+					type: 'audio',
+					subtype: 'podcast', // only podcast is audio subtype at 03/2019. Need to change when audio has more subtypes.
+				};
+			}
+		});
+	}
+};
+
+module.exports = audioTeaserView;

--- a/components/n-ui/tracking/index.js
+++ b/components/n-ui/tracking/index.js
@@ -1,3 +1,5 @@
+const oTracking = require('o-tracking');
+
 module.exports = {
 	init: function (flags, appInfo) {
 		require('./ft').init(flags, appInfo);
@@ -8,6 +10,6 @@ module.exports = {
 		});
 	},
 	scrollDepthComponents: require('./ft/events/scroll-depth-components'),
-	scrollDepth: require('./ft/events/scroll-depth')
-
+	scrollDepth: require('./ft/events/scroll-depth'),
+	view: oTracking.view
 };

--- a/components/n-ui/tracking/index.js
+++ b/components/n-ui/tracking/index.js
@@ -1,5 +1,3 @@
-const oTracking = require('o-tracking');
-
 module.exports = {
 	init: function (flags, appInfo) {
 		require('./ft').init(flags, appInfo);
@@ -11,5 +9,5 @@ module.exports = {
 	},
 	scrollDepthComponents: require('./ft/events/scroll-depth-components'),
 	scrollDepth: require('./ft/events/scroll-depth'),
-	view: oTracking.view
+	audioTeaserView: require('./ft/events/audio-teaser-view')
 };


### PR DESCRIPTION
To apply audio teaser view tracking for next-article, next-stream-page and next-front-page.

This PR need to be merged after o-tracking is released.
https://github.com/Financial-Times/o-tracking/pull/199/

 🐿 v2.12.0