### PR TITLE
Added missing ad-related performance mark

### DIFF
--- a/components/n-ui/ads/js/page-metrics.js
+++ b/components/n-ui/ads/js/page-metrics.js
@@ -6,7 +6,8 @@ const eventToPerfmarkMap = {
 	startInitialisation: 'adsInitialising',
 	moatIVTcomplete: 'adsIVTComplete',
 	apiRequestsComplete: 'adsTargetingComplete',
-	initialised: 'adsPreparationComplete'
+	initialised: 'adsPreparationComplete',
+	adServerLoadSuccess: 'adsServerLoaded'
 };
 
 const setupPageMetrics = () => {
@@ -30,8 +31,9 @@ const recordMarksForEvents = (events2Marks) => {
 
 const sendPageMetricsWhenPageReady = () => {
 	document.addEventListener('oAds.adServerLoadSuccess', function listenOnInitialised() {
-		sendMetrics();
-		document.addEventListener('oAds.adServerLoadSuccess', listenOnInitialised);
+		// We must ensure the 'adsServerLoaded' perfMark has been recorded first
+		setTimeout(sendMetrics, 0)
+		document.removeEventListener('oAds.adServerLoadSuccess', listenOnInitialised);
 	});
 };
 

--- a/components/n-ui/ads/test/page-metrics.spec.js
+++ b/components/n-ui/ads/test/page-metrics.spec.js
@@ -1,6 +1,9 @@
 /* globals describe, it, beforeEach, afterEach,expect,sinon */
 const pageMetrics = require('../js/page-metrics');
 const broadcastStub = sinon.stub();
+
+// In reality, we are sampling the number of users that send metrics
+// to Spoor which, without this stub, would lead to flaky tests
 const inMetricsSampleStub = sinon.stub().callsFake(() => true);
 
 // Inject the broadcastStub into sendMetrics with Rewire
@@ -42,13 +45,14 @@ describe('Page Metrics', () => {
 		}, 0);
 	});
 
-	it('should broadcast oTracking.event with the right performance marks', () => {
+	it('should broadcast oTracking.event with the right performance marks', (done) => {
 		const getEntriesByNameStub = sinon.stub();
 		getEntriesByNameStub.withArgs('somethingElse').returns([{ name: 'somethingElse', startTime: 400 }]);
 		getEntriesByNameStub.withArgs('adsInitialising').returns([{ name: 'adsInitialising', startTime: 500.22 }]);
 		getEntriesByNameStub.withArgs('adsIVTComplete').returns([{ name: 'adsIVTComplete', startTime: 600.64 }]);
 		getEntriesByNameStub.withArgs('adsTargetingComplete').returns([{ name: 'adsTargetingComplete', startTime: 700.45 }]);
 		getEntriesByNameStub.withArgs('adsPreparationComplete').returns([{ name: 'adsPreparationComplete', startTime: 705.57 }]);
+		getEntriesByNameStub.withArgs('adsServerLoaded').returns([{ name: 'adsServerLoaded', startTime: 905.57 }]);
 
 		window.performance = {
 			getEntriesByName: getEntriesByNameStub
@@ -62,14 +66,39 @@ describe('Page Metrics', () => {
 					adsInitialising: 500,
 					adsIVTComplete: 601,
 					adsTargetingComplete: 700,
-					adsPreparationComplete: 706
+					adsPreparationComplete: 706,
+					adsServerLoaded: 906
 				}
 			}
 		};
 
 		pageMetrics.setupPageMetrics();
 		document.dispatchEvent(new CustomEvent('oAds.adServerLoadSuccess'));
-		expect(broadcastStub).to.have.been.calledWith('oTracking.event', expectedTrackingObject);
+		setTimeout( () => {
+			expect(broadcastStub).to.have.been.calledWith('oTracking.event', expectedTrackingObject);
+			done();
+		});
+	});
+
+	it('captures all the expected page metrics', (done) => {
+		pageMetrics.setupPageMetrics();
+		document.dispatchEvent(new CustomEvent('oAds.startInitialisation'));
+		document.dispatchEvent(new CustomEvent('oAds.apiRequestsComplete'));
+		document.dispatchEvent(new CustomEvent('oAds.moatIVTcomplete'));
+		document.dispatchEvent(new CustomEvent('oAds.initialised'));
+		document.dispatchEvent(new CustomEvent('oAds.adServerLoadSuccess'));
+
+		setTimeout( () => {
+			expect(broadcastStub).to.have.been.called;
+			const marksObject = broadcastStub.firstCall.args[1].timings.marks;
+			expect(marksObject.adsInitialising).to.be.a('number');
+			expect(marksObject.adsIVTComplete).to.be.a('number');
+			expect(marksObject.adsTargetingComplete).to.be.a('number');
+			expect(marksObject.adsPreparationComplete).to.be.a('number');
+			expect(marksObject.adsServerLoaded).to.be.a('number');
+			done();
+		});
+		// expect(broadcastStub).to.have.been.calledWith('oTracking.event');
 	});
 });
 


### PR DESCRIPTION
This adds a missing time mark,`adServerLoadSuccess`, to the new ad performance metrics which indicates the end of the page preparation process for loading ads.