### PR TITLE
Fix gpt beta live issue

### DIFF
--- a/components/n-ui/ads/js/oAdsConfig.js
+++ b/components/n-ui/ads/js/oAdsConfig.js
@@ -22,12 +22,6 @@ module.exports = function (flags, appName, adOptions) {
 	// TO-DO: Check if we can get rid of this 'extend' and pass an object literal
 	let targeting = extend(targetingOptions);
 
-	// This is a beta feature from google to enable long lived pageview data.
-	// This is needed for master companion ads when there could be ads out of view further down the page
-	if (appName === 'article') {
-		targeting['gpt-beta'] = 'hzwxrfqd';
-	}
-
 	const kruxConfig = (flags.get('krux')) && !adOptions.noTargeting && {
 		id: 'KHUSeE3x',
 		attributes: {

--- a/components/n-ui/ads/test/oAdsConfig.spec.js
+++ b/components/n-ui/ads/test/oAdsConfig.spec.js
@@ -86,7 +86,7 @@ describe('Config', () => {
 			const flags = { get: () => true };
 			const config = oAdsConfig(flags, 'article' );
 			document.cookie = 'FT_U=EID=1234_PID=abc';
-			const expectation = 'pt=art;nlayout=custom;testads=true;gpt-beta=hzwxrfqd'.split(';');
+			const expectation = 'pt=art;nlayout=custom;testads=true'.split(';');
 
 			expectation.forEach((value) => expect(config.dfp_targeting).to.contain(value));
 		});


### PR DESCRIPTION
Our integration with Google's client-side ad loading library is causing JS errors. Google previously instructed us to set a key/value parameter that would enable "beta features" of the library - however in a recent update the Google script appears to throw a JS error when the feature is enabled. We are now disabling the beta-feature.