### PR TITLE
Adding new google verification code to allow new site owners

### DIFF
--- a/browser/layout/wrapper.html
+++ b/browser/layout/wrapper.html
@@ -78,6 +78,7 @@
 		{{/unless}}
 		{{#if @root.flags.googleSiteVerificationMeta}}
 		<meta name="google-site-verification" content="4-t8sFaPvpO5FH_Gnw1dkM28CQepjzo8UjjAkdDflTw" />
+		<meta name="google-site-verification" content="NBMsS8KuY5qJbd9AVvcUAG6k5t9pI7sTAg-irHc3byQ" />
 		{{/if}}
 
 		{{#outputBlock 'head'}}{{/outputBlock}}


### PR DESCRIPTION
We cannot discover who the original owner is for 'https://search.google.com/search-console/welcome' so cannot add new users / no one but James Webb seems able to view this page.  We presume they (Rob Shilston?) may have left the company.

The addition of this new code should enable me to view all other owners and add new owners.  I will then share this ownership more widely so we are no longer locked out.

Information for this found on the [google help article - 'We lost our site owner!'](https://support.google.com/webmasters/answer/7687615?authuser=0):

> We lost our site owner!
> If the verified owner of your site leaves, or you're not sure who the verified owner is, verify another site owner. The new owner will be able to see the list of all owners and users verified to that site, as well as the verification methods for each owner. You can then optionally unverify previous owners by removing their verification token (for example, removing the HTML tag from the site, for HTML-tag-verified owners).