### PR TITLE
Improved the way we sample users who send ads metrics

### DIFF
--- a/components/n-ui/ads/js/utils.js
+++ b/components/n-ui/ads/js/utils.js
@@ -130,7 +130,7 @@ const inMetricsSample = (() => {
 	const decideInMetricsSample = () => {
 
 		// We are caching the value since we want to be consistent with the user
-		// allocation throughout one same session
+		// allocation throughout one same page visit
 		if (typeof userSendsMetrics !== 'undefined') {
 			return userSendsMetrics;
 		}

--- a/components/n-ui/ads/js/utils.js
+++ b/components/n-ui/ads/js/utils.js
@@ -122,9 +122,25 @@ function getScreenSize () {
 	return window.innerWidth;
 }
 
-function inMetricsSample() {
-	return /spoor-id=3/.test(document.cookie);
-}
+// Fraction of all users that will actually send ads metrics to Spoor
+const METRICS_SAMPLE_SIZE = 0.1;
+
+const inMetricsSample = (() => {
+	let userSendsMetrics;
+	const decideInMetricsSample = () => {
+
+		// We are caching the value since we want to be consistent with the user
+		// allocation throughout one same session
+		if (typeof userSendsMetrics !== 'undefined') {
+			return userSendsMetrics;
+		}
+
+		userSendsMetrics = (Math.random() < METRICS_SAMPLE_SIZE);
+		return userSendsMetrics;
+
+	};
+	return decideInMetricsSample;
+})();
 
 module.exports = {
 	debounce: debounce,

--- a/components/n-ui/ads/test/utils.spec.js
+++ b/components/n-ui/ads/test/utils.spec.js
@@ -218,4 +218,16 @@ describe('Utils', () => {
 		expect(utils.getReferrer()).to.equal(document.referrer);
 	});
 
+	it.only('Should return the same value for inMetricsSample when called multiple times', () => {
+		const firstValue = utils.inMetricsSample();
+
+		let count = 0;
+		for (let i = 0; i < 100; i++) {
+			if (utils.inMetricsSample() === firstValue) {
+				count++;
+			}
+		}
+		expect(count).to.equal(100);
+	});
+
 });


### PR DESCRIPTION
The ads team has agreed on sending metrics to spoor for only 10% of all users.

Until now, we were using the spoor-id cookie to allocate users in send/no-send groups. However, spoor ids can take several shapes as there are not strong requirements for them and they currently come in, at least, two different shapes.

Using `Math.random` gives us more control over the granularity of the sample size and makes it easier to reason about it, while still achieving the main goal of this sampling which is not flooding Spoor with too many events unnecessarily.

For every page visit a user is placed consistently in a send/no-send group which should make it easier to compare metrics from different requests to Spoor.