### PR TITLE
Modify contentId => componentContentId

### DIFF
--- a/components/n-ui/tracking/ft/events/audio-teaser-view.js
+++ b/components/n-ui/tracking/ft/events/audio-teaser-view.js
@@ -9,7 +9,7 @@ const audioTeaserView = {
 			selector: selector || '.o-teaser--audio',
 			getContextData: (el) => {
 				return {
-					contentId: getContentIdFromXTeaser(el) || getContentIdFromNTeaser(el),
+					componentContentId: getContentIdFromXTeaser(el) || getContentIdFromNTeaser(el),
 					component: 'teaser',
 					type: 'audio',
 					subtype: 'podcast', // only podcast is audio subtype at 03/2019. Need to change when audio has more subtypes.


### PR DESCRIPTION
Impressions on article pages have both contentID and rootContentID is potentially confusing. We rename contentID to componentContentID so it is very clear what that applies to.

 🐿 v2.12.0