### PR TITLE
Send krux metrics

### DIFF
--- a/components/n-ui/ads/js/page-metrics.js
+++ b/components/n-ui/ads/js/page-metrics.js
@@ -23,8 +23,8 @@ const setupPageMetrics = () => {
 	recordMarksForEvents(pageEventMarkMap);
 
 	sendMetricsOnEvent('oAds.kruxKuidAck', sendKruxMetrics);
-	recordMarksForEvents(kruxEventMarkMap);
 	sendMetricsOnEvent('oAds.kruxKuidError', sendKruxMetrics);
+	sendMetricsOnEvent('oAds.kruxConsentOptinFailed', sendKruxMetrics);
 	recordMarksForEvents(kruxEventMarkMap);
 
 };
@@ -42,8 +42,6 @@ const recordMarksForEvents = (events2Marks) => {
 		recordPerfMarkForEvent(eventName, events2Marks[eventName]);
 	}
 };
-
-const performance = window.performance || window.msPerformance || window.webkitPerformance || window.mozPerformance;
 
 const getMarksForEventMarkMap = eventMarkMap => {
 	let markNames = [];
@@ -88,6 +86,7 @@ const sendMetricsOnEvent = (eventName, callback) => {
 };
 
 const getPerfMarks = (markNames) => {
+	const performance = window.performance || window.msPerformance || window.webkitPerformance || window.mozPerformance;
 	if (!performance || !performance.getEntriesByName) {
 		return {};
 	}

--- a/components/n-ui/ads/js/page-metrics.js
+++ b/components/n-ui/ads/js/page-metrics.js
@@ -22,9 +22,9 @@ const setupPageMetrics = () => {
 	sendMetricsOnEvent('oAds.adServerLoadSuccess', sendPageMetrics);
 	recordMarksForEvents(pageEventMarkMap);
 
-	sendMetricsOnEvent('oAds.kruxKuidAck', sendKruxMetrics);
-	sendMetricsOnEvent('oAds.kruxKuidError', sendKruxMetrics);
-	sendMetricsOnEvent('oAds.kruxConsentOptinFailed', sendKruxMetrics);
+	// sendMetricsOnEvent('oAds.kruxKuidAck', sendKruxMetrics);
+	// sendMetricsOnEvent('oAds.kruxKuidError', sendKruxMetrics);
+	// sendMetricsOnEvent('oAds.kruxConsentOptinFailed', sendKruxMetrics);
 	recordMarksForEvents(kruxEventMarkMap);
 
 };
@@ -53,28 +53,24 @@ const getMarksForEventMarkMap = eventMarkMap => {
 	return getPerfMarks(markNames);
 }
 
-const sendPageMetrics = () => {
+const sendMetrics = (eventMarkMap, actionName) => {
 	if (inMetricsSample()) {
-		const marks = getMarksForEventMarkMap(pageEventMarkMap);
+		const marks = getMarksForEventMarkMap(eventMarkMap);
 
 		broadcast('oTracking.event', {
 			category: 'ads',
-			action: 'page-initialised',
+			action: actionName,
 			timings: { marks }
 		});
 	}
 };
 
-const sendKruxMetrics = () => {
-	if (inMetricsSample()) {
-		const marks = getMarksForEventMarkMap(kruxEventMarkMap);
+const sendPageMetrics = () => {
+	sendMetrics(pageEventMarkMap, 'page-initialised');
+};
 
-		broadcast('oTracking.event', {
-			category: 'ads',
-			action: 'krux',
-			timings: { marks }
-		});
-	}
+const sendKruxMetrics = () => {
+	sendMetrics(kruxEventMarkMap, 'krux');
 };
 
 const sendMetricsOnEvent = (eventName, callback) => {

--- a/components/n-ui/ads/js/page-metrics.js
+++ b/components/n-ui/ads/js/page-metrics.js
@@ -11,11 +11,11 @@ const pageEventMarkMap = {
 };
 
 const kruxEventMarkMap = {
-	kruxScriptLoaded: 'kruxScriptLoaded',
-	kruxConsentOptinOK: 'kruxConsentOptinOK',
-	kruxConsentOptinFailed: 'kruxConsentOptinFailed',
-	kruxKuidAck: 'kruxKuidAck',
-	kruxKuidError: 'kruxKuidError'
+	kruxScriptLoaded,
+	kruxConsentOptinOK,
+	kruxConsentOptinFailed,
+	kruxKuidAck,
+	kruxKuidError,
 };
 
 const setupPageMetrics = () => {

--- a/components/n-ui/ads/js/page-metrics.js
+++ b/components/n-ui/ads/js/page-metrics.js
@@ -22,9 +22,9 @@ const setupPageMetrics = () => {
 	sendMetricsOnEvent('oAds.adServerLoadSuccess', sendPageMetrics);
 	recordMarksForEvents(pageEventMarkMap);
 
-	// sendMetricsOnEvent('oAds.kruxKuidAck', sendKruxMetrics);
-	// sendMetricsOnEvent('oAds.kruxKuidError', sendKruxMetrics);
-	// sendMetricsOnEvent('oAds.kruxConsentOptinFailed', sendKruxMetrics);
+	sendMetricsOnEvent('oAds.kruxKuidAck', sendKruxMetrics);
+	sendMetricsOnEvent('oAds.kruxKuidError', sendKruxMetrics);
+	sendMetricsOnEvent('oAds.kruxConsentOptinFailed', sendKruxMetrics);
 	recordMarksForEvents(kruxEventMarkMap);
 
 };

--- a/components/n-ui/ads/js/page-metrics.js
+++ b/components/n-ui/ads/js/page-metrics.js
@@ -11,11 +11,11 @@ const pageEventMarkMap = {
 };
 
 const kruxEventMarkMap = {
-	kruxScriptLoaded,
-	kruxConsentOptinOK,
-	kruxConsentOptinFailed,
-	kruxKuidAck,
-	kruxKuidError,
+	kruxScriptLoaded: 'kruxScriptLoaded',
+	kruxConsentOptinOK: 'kruxConsentOptinOK',
+	kruxConsentOptinFailed: 'kruxConsentOptinFailed',
+	kruxKuidAck: 'kruxKuidAck',
+	kruxKuidError: 'kruxKuidError'
 };
 
 const setupPageMetrics = () => {

--- a/components/n-ui/ads/test/page-metrics.spec.js
+++ b/components/n-ui/ads/test/page-metrics.spec.js
@@ -25,12 +25,12 @@ describe('Page Metrics', () => {
 	});
 
 	it('should record a performance mark for each of the expected events only once', (done) => {
-		const eventToPerfmarkMap = {
+		const pageEventMarkMap = {
 			foo: 'fooPerfMark',
 			bar: 'barPerfMark'
 		};
 
-		pageMetrics.recordMarksForEvents(eventToPerfmarkMap);
+		pageMetrics.recordMarksForEvents(pageEventMarkMap);
 
 		document.dispatchEvent(new CustomEvent('oAds.foo'));
 		document.dispatchEvent(new CustomEvent('oAds.bar'));

--- a/components/n-ui/ads/test/page-metrics.spec.js
+++ b/components/n-ui/ads/test/page-metrics.spec.js
@@ -98,7 +98,140 @@ describe('Page Metrics', () => {
 			expect(marksObject.adsServerLoaded).to.be.a('number');
 			done();
 		});
-		// expect(broadcastStub).to.have.been.calledWith('oTracking.event');
+	});
+
+	it('should broadcast an oTracking.event with the right krux marks when Kuid has been acknowledged', (done) => {
+		const getEntriesByNameStub = sinon.stub();
+		getEntriesByNameStub.withArgs('kruxScriptLoaded').returns([{ name: 'kruxScriptLoaded', startTime: 700.45 }]);
+		getEntriesByNameStub.withArgs('kruxConsentOptinOK').returns([{ name: 'kruxConsentOptinOK', startTime: 705.57 }]);
+		getEntriesByNameStub.withArgs('kruxKuidAck').returns([{ name: 'kruxKuidAck', startTime: 905.57 }]);
+
+		window.performance = {
+			getEntriesByName: getEntriesByNameStub
+		};
+
+		const expectedTrackingObject = {
+			category: 'ads',
+			action: 'krux',
+			timings: {
+				marks: {
+					kruxScriptLoaded: 700,
+					kruxConsentOptinOK: 706,
+					kruxKuidAck: 906
+				}
+			}
+		};
+
+		pageMetrics.setupPageMetrics();
+		document.dispatchEvent(new CustomEvent('oAds.kruxKuidAck'));
+		setTimeout( () => {
+			expect(broadcastStub).to.have.been.calledWith('oTracking.event', expectedTrackingObject);
+			done();
+		});
+	});
+
+	it('should broadcast an oTracking.event with the right krux marks when Kuid has NOT been acknowledged', (done) => {
+		const getEntriesByNameStub = sinon.stub();
+		getEntriesByNameStub.withArgs('kruxScriptLoaded').returns([{ name: 'kruxScriptLoaded', startTime: 700.45 }]);
+		getEntriesByNameStub.withArgs('kruxConsentOptinOK').returns([{ name: 'kruxConsentOptinOK', startTime: 705.57 }]);
+		getEntriesByNameStub.withArgs('kruxKuidError').returns([{ name: 'kruxKuidError', startTime: 905.57 }]);
+
+		window.performance = {
+			getEntriesByName: getEntriesByNameStub
+		};
+
+		const expectedTrackingObject = {
+			category: 'ads',
+			action: 'krux',
+			timings: {
+				marks: {
+					kruxScriptLoaded: 700,
+					kruxConsentOptinOK: 706,
+					kruxKuidError: 906
+				}
+			}
+		};
+
+		pageMetrics.setupPageMetrics();
+		document.dispatchEvent(new CustomEvent('oAds.kruxKuidAck'));
+		setTimeout( () => {
+			expect(broadcastStub).to.have.been.calledWith('oTracking.event', expectedTrackingObject);
+			done();
+		});
+	});
+
+	it('should broadcast an oTracking.event with the right krux marks when consent was not given', (done) => {
+		const getEntriesByNameStub = sinon.stub();
+		getEntriesByNameStub.withArgs('kruxScriptLoaded').returns([{ name: 'kruxScriptLoaded', startTime: 700.45 }]);
+		getEntriesByNameStub.withArgs('kruxConsentOptinFailed').returns([{ name: 'kruxConsentOptinFailed', startTime: 705.57 }]);
+
+		window.performance = {
+			getEntriesByName: getEntriesByNameStub
+		};
+
+		const expectedTrackingObject = {
+			category: 'ads',
+			action: 'krux',
+			timings: {
+				marks: {
+					kruxScriptLoaded: 700,
+					kruxConsentOptinFailed: 706
+				}
+			}
+		};
+
+		pageMetrics.setupPageMetrics();
+		document.dispatchEvent(new CustomEvent('oAds.kruxConsentOptinFailed'));
+		setTimeout( () => {
+			expect(broadcastStub).to.have.been.calledWith('oTracking.event', expectedTrackingObject);
+			done();
+		});
+	});
+
+	it('captures all the expected krux metrics when Kuid has been acknowledged', (done) => {
+		pageMetrics.setupPageMetrics();
+		document.dispatchEvent(new CustomEvent('oAds.kruxScriptLoaded'));
+		document.dispatchEvent(new CustomEvent('oAds.kruxConsentOptinOK'));
+		document.dispatchEvent(new CustomEvent('oAds.kruxKuidAck'));
+
+		setTimeout( () => {
+			expect(broadcastStub).to.have.been.called;
+			const marksObject = broadcastStub.firstCall.args[1].timings.marks;
+			expect(marksObject.kruxScriptLoaded).to.be.a('number');
+			expect(marksObject.kruxConsentOptinOK).to.be.a('number');
+			expect(marksObject.kruxKuidAck).to.be.a('number');
+			done();
+		});
+	});
+
+	it('captures all the expected krux metrics when Kuid has NOT been acknowledged', (done) => {
+		pageMetrics.setupPageMetrics();
+		document.dispatchEvent(new CustomEvent('oAds.kruxScriptLoaded'));
+		document.dispatchEvent(new CustomEvent('oAds.kruxConsentOptinOK'));
+		document.dispatchEvent(new CustomEvent('oAds.kruxKuidError'));
+
+		setTimeout( () => {
+			expect(broadcastStub).to.have.been.called;
+			const marksObject = broadcastStub.firstCall.args[1].timings.marks;
+			expect(marksObject.kruxScriptLoaded).to.be.a('number');
+			expect(marksObject.kruxConsentOptinOK).to.be.a('number');
+			expect(marksObject.kruxKuidError).to.be.a('number');
+			done();
+		});
+	});
+
+	it('captures all the expected krux metrics when consent was not given', (done) => {
+		pageMetrics.setupPageMetrics();
+		document.dispatchEvent(new CustomEvent('oAds.kruxScriptLoaded'));
+		document.dispatchEvent(new CustomEvent('oAds.kruxConsentOptinFailed'));
+
+		setTimeout( () => {
+			expect(broadcastStub).to.have.been.called;
+			const marksObject = broadcastStub.firstCall.args[1].timings.marks;
+			expect(marksObject.kruxScriptLoaded).to.be.a('number');
+			expect(marksObject.kruxConsentOptinFailed).to.be.a('number');
+			done();
+		});
 	});
 });
 

--- a/components/n-ui/ads/test/utils.spec.js
+++ b/components/n-ui/ads/test/utils.spec.js
@@ -218,7 +218,7 @@ describe('Utils', () => {
 		expect(utils.getReferrer()).to.equal(document.referrer);
 	});
 
-	it.only('Should return the same value for inMetricsSample when called multiple times', () => {
+	it('Should return the same value for inMetricsSample when called multiple times', () => {
 		const firstValue = utils.inMetricsSample();
 
 		let count = 0;


### PR DESCRIPTION
Added a new spoor request for sending krux performance metrics when the krux behavioural consent verification process has finished (which can finish in a number of different ways).

The refactor here makes it simpler to send a spoor request which a bunch of metrics when a specific `oAds` event occurs, enabling future work on new metrics to be collected.