### PR TITLE
Allow polyfill.io responses to be cache busted on browser

### DIFF
--- a/server/lib/asset-manager/polyfill-io.js
+++ b/server/lib/asset-manager/polyfill-io.js
@@ -1,4 +1,12 @@
 const polyfillRoot = 'https://www.ft.com/__origami/service/polyfill/v3/polyfill.min.js';
+
+/**
+ * For the instances where we need to clear polyfill.io responses from users' browsers
+ * Generated using:
+ * node -e 'console.log(parseInt((new Date().getTime())/1000))'
+ */
+const cacheBuster = 1552915810;
+
 function buildQueryString (qsConfig) {
 	const qs = [];
 
@@ -7,7 +15,7 @@ function buildQueryString (qsConfig) {
 		qs.push(`${key}=${Array.isArray(val) ? val.join(',') : val}`);
 	});
 
-	qs.push('source=next', 'unknown=polyfill');
+	qs.push('source=next', 'unknown=polyfill', `cb=${cacheBuster}`);
 
 	return `?${qs.join('&')}`;
 }


### PR DESCRIPTION
A recent change to the polyfill service resulted in incorrect responses being returned to user agents. This has now been fixed [here](https://github.com/Financial-Times/polyfill-service/pull/1920), but since the `max-age` header is set to a week for polyfill.io responses, it'll be a while before it's picked up by users.

This change sets a query string parameter that will force browsers to clear their cached polyfill responses. Given the polyfill request is the same across all n-ui apps, it should only happen once per user, regardless of how many apps they visit after this change is released.





 🐿 v2.12.2