### PR TITLE
Fix `make deploy` target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -133,6 +133,7 @@ deploy-s3:
 	nht deploy-hashed-assets --directory public/n-ui --monitor-assets
 
 deploy: deploy-s3 npm-publish rebuild-user-facing-apps
+	@$(DONE) # This is required so that n-gage's `deploy` target doesn't run
 
 rebuild-user-facing-apps:
 # Don't rebuild apps if a beta tag release


### PR DESCRIPTION
If a target is overridden in a project's `Makefile`, then it must have content (i.e. run a command) in order for the original `n-gage` target not to run. As the `deploy` target in this project was only calling other targets and not defining its own content, `n-gage`'s `deploy` target was being run afterwards and then producing an error as it is only intended for deploying our apps to Heroku.

Related failed build (which actually succeeded): https://circleci.com/gh/Financial-Times/n-ui/8141