### PR TITLE
Remove obsolete headline testing code (superseded by Teaser Testing)

### DIFF
--- a/components/n-ui/tracking/ft/index.js
+++ b/components/n-ui/tracking/ft/index.js
@@ -119,17 +119,6 @@ const oTrackingWrapper = {
 				useSendBeacon: flags.get('sendBeacon')
 			});
 
-			//headline testing, add variant to the page view event as long as there is only one article under test
-			if (location.pathname === '/') {
-				const alternativeHeadlines = [].slice.call(document.querySelectorAll('[data-trackable-context-headline-variant]'));
-				const isOnlyOneArticle = alternativeHeadlines.every((element, index, array) => element.getAttribute('href') === array[0].getAttribute('href'));
-				if (alternativeHeadlines.length && isOnlyOneArticle) {
-					pageViewConf.context['headline-variant'] = alternativeHeadlines[0].getAttribute('data-trackable-context-headline-variant');
-					const articleUuid = alternativeHeadlines[0].getAttribute('href').replace('/content/', '');
-					pageViewConf.context['headline-uuid'] = articleUuid;
-				}
-			}
-
 			//teaser-testing (supersedes 'headline' testing). Add extra page context info related to the relevant teasers under test.
 			if (location.pathname === '/') {
 				pageViewConf.context['teaser_tests'] = abTestHelpers.getTeaserTestContext(document);


### PR DESCRIPTION
 🐿 v2.12.2