### PR TITLE
Removing a no longer needed google verification code.

### DIFF
--- a/browser/layout/wrapper.html
+++ b/browser/layout/wrapper.html
@@ -78,7 +78,6 @@
 		{{/unless}}
 		{{#if @root.flags.googleSiteVerificationMeta}}
 		<meta name="google-site-verification" content="4-t8sFaPvpO5FH_Gnw1dkM28CQepjzo8UjjAkdDflTw" />
-		<meta name="google-site-verification" content="NBMsS8KuY5qJbd9AVvcUAG6k5t9pI7sTAg-irHc3byQ" />
 		{{/if}}
 
 		{{#outputBlock 'head'}}{{/outputBlock}}


### PR DESCRIPTION
I added this as I could not find anyone who had permissions to the google search console.  I had to add this code to be able to see who has permissions / add myself. Now I've gained access I have also added all the principal engineers as owners and all tech leads as having full rights.

I am now removing the verification code I previously added and leaving just the original in place (as housekeeping mainly, I think this change will have no effect on the current access levels)

 🐿 v2.12.2