### PR TITLE
Add asset type overrides

### DIFF
--- a/components/n-ui/tracking/ft/index.js
+++ b/components/n-ui/tracking/ft/index.js
@@ -59,6 +59,12 @@ const oTrackingWrapper = {
 			const errorReason = (/nextErrorReason=(\w+)/.exec(window.location.search) || [])[1];
 			const pageViewConf = {context: {}};
 
+			if (getRootData('content-type') === 'podcast' || getRootData('content-type') === 'audio') {
+				pageViewConf.context.content = {
+					asset_type: 'audio'
+				};
+			}
+
 			if (errorStatus) {
 				// TODO after https://github.com/Financial-Times/o-tracking/issues/122#issuecomment-194970465
 				// this should be redundant as context would propagate down to each event in its entirety


### PR DESCRIPTION
wait for https://github.com/Financial-Times/next-article/pull/3296/files

As requested by data intelligence team, add asset type to indicate audio types.
App already does this
Default is article

 🐿 v2.12.3

