### PR TITLE
Ads - including Permutive origami component for a trial - all functio…

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -23,6 +23,7 @@
     "n-ui-foundations": "^3.0.6",
     "next-session-client": "^2.3.4",
     "o-ads": "^12.1.0",
+    "o-permutive": "1.0.0-beta.2",
     "o-errors": "^3.6.1",
     "o-expander": "^4.4.4",
     "o-footer": "^6.0.10",

--- a/browser/layout/wrapper.html
+++ b/browser/layout/wrapper.html
@@ -167,5 +167,12 @@
 	{{#if @root.flags.adsInizioSurvey}}
 		{{>n-ui/brandmetrics/template}}
 	{{/if}}
+	{{#if @root.flags.AdsPermutive}}
+	//Trial behind a flag - Testing permutive functionality
+	<div style="display:none">
+		<div class="o-permutive" data-o-component="o-permutive"
+		data-o-permutive-auoto-init="false"></div>
+	</div>
+	{{/if}}
 	</body>
 </html>

--- a/components/n-ui/ads/index.js
+++ b/components/n-ui/ads/index.js
@@ -62,7 +62,7 @@ function onAdsComplete (flags, event) {
 
 export default {
 	//Permutive trial - config
-	let oPermConf = {
+	const oPermConf = {
 		'appInfo' : {
 			'appName' : 'article',
 			'contentId' : '5cfae92e-6cc5-11e9-80c7-60ee53e6681d'

--- a/components/n-ui/ads/index.js
+++ b/components/n-ui/ads/index.js
@@ -61,6 +61,21 @@ function onAdsComplete (flags, event) {
 }
 
 export default {
+	//Permutive trial - config
+	let oPermConf = {
+		'appInfo' : {
+			'appName' : 'article',
+			'contentId' : '5cfae92e-6cc5-11e9-80c7-60ee53e6681d'
+		},
+		'publicApiKeys' : {
+			'id' : 'e1c3fd73-dd41-4abd-b80b-4278d52bf7aa',
+			'key' : 'b2b3b748-e1f6-4bd5-b2f2-26debc8075a3'
+		},
+		'adsApi' : {
+			'user' : 'https://ads-api.ft.com/v1/user',
+			'content' : 'https://ads-api.ft.com/v1/content/'
+		}
+	};
 	init: (flags, appInfo, opts) => {
 
 		window.addEventListener('ftNextLoaded', function () {
@@ -68,20 +83,6 @@ export default {
 		});
 
 		if (flags && flags.get('AdsPermutive')) {
-			let oPermConf = {
-				'appInfo' : {
-					'appName' : 'article',
-					'contentId' : '5cfae92e-6cc5-11e9-80c7-60ee53e6681d'
-				},
-				'publicApiKeys' : {
-					'id' : 'e1c3fd73-dd41-4abd-b80b-4278d52bf7aa',
-					'key' : 'b2b3b748-e1f6-4bd5-b2f2-26debc8075a3'
-				},
-				'adsApi' : {
-					'user' : 'https://ads-api.ft.com/v1/user',
-					'content' : 'https://ads-api.ft.com/v1/content/'
-				}
-			};
 			oPermutive.init(false, oPermConf);
 		}
 

--- a/components/n-ui/ads/index.js
+++ b/components/n-ui/ads/index.js
@@ -1,5 +1,6 @@
 import krux from './js/krux';
 import Ads from 'o-ads';
+import oPermutive from 'o-permutive';
 
 //TODO move to central shared utils
 import utils from './js/utils';
@@ -66,6 +67,24 @@ export default {
 			nCounterAdBlocking.init(flags);
 		});
 
+		if (flags && flags.get('AdsPermutive')) {
+			let oPermConf = {
+				'appInfo' : {
+					'appName' : 'article',
+					'contentId' : '5cfae92e-6cc5-11e9-80c7-60ee53e6681d'
+				},
+				'publicApiKeys' : {
+					'id' : 'e1c3fd73-dd41-4abd-b80b-4278d52bf7aa',
+					'key' : 'b2b3b748-e1f6-4bd5-b2f2-26debc8075a3'
+				},
+				'adsApi' : {
+					'user' : 'https://ads-api.ft.com/v1/user',
+					'content' : 'https://ads-api.ft.com/v1/content/'
+				}
+			};
+			oPermutive.init(false, oPermConf);
+		}
+
 		const adOptions = typeof opts === 'object' ? opts : {};
 
 		return Promise.resolve()
@@ -93,6 +112,6 @@ export default {
 						});
 				}
 
-		});
+			});
 	}
 };

--- a/components/n-ui/ads/index.js
+++ b/components/n-ui/ads/index.js
@@ -59,6 +59,8 @@ function onAdsComplete (flags, event) {
 		utils.log('Ads component finished');
 	}
 }
+
+//Permutive Trial - config options for o-permutive component.
 const oPermConf = {
 	'appInfo' : {
 		'appName' : 'article',

--- a/components/n-ui/ads/index.js
+++ b/components/n-ui/ads/index.js
@@ -59,31 +59,27 @@ function onAdsComplete (flags, event) {
 		utils.log('Ads component finished');
 	}
 }
-	const oPermConf = {
-		'appInfo' : {
-			'appName' : 'article',
-			'contentId' : '5cfae92e-6cc5-11e9-80c7-60ee53e6681d'
-		},
-		'publicApiKeys' : {
-			'id' : 'e1c3fd73-dd41-4abd-b80b-4278d52bf7aa',
-			'key' : 'b2b3b748-e1f6-4bd5-b2f2-26debc8075a3'
-		},
-		'adsApi' : {
-			'user' : 'https://ads-api.ft.com/v1/user',
-			'content' : 'https://ads-api.ft.com/v1/content/'
-			}
-	};
+const oPermConf = {
+	'appInfo' : {
+		'appName' : 'article',
+		'contentId' : '5cfae92e-6cc5-11e9-80c7-60ee53e6681d'
+	},
+	'publicApiKeys' : {
+		'id' : 'e1c3fd73-dd41-4abd-b80b-4278d52bf7aa',
+		'key' : 'b2b3b748-e1f6-4bd5-b2f2-26debc8075a3'
+	},
+	'adsApi' : {
+		'user' : 'https://ads-api.ft.com/v1/user',
+		'content' : 'https://ads-api.ft.com/v1/content/'
+	}
+};
 export default {
 	init: (flags, appInfo, opts) => {
 
 		window.addEventListener('ftNextLoaded', function () {
 			nCounterAdBlocking.init(flags);
 		});
-
-		if (flags && flags.get('AdsPermutive')) {
-			oPermutive.init(false, oPermConf);
-		}
-
+		if (flags && flags.get('AdsPermutive')) { oPermutive.init(false, oPermConf);}
 		const adOptions = typeof opts === 'object' ? opts : {};
 
 		return Promise.resolve()

--- a/components/n-ui/ads/index.js
+++ b/components/n-ui/ads/index.js
@@ -59,9 +59,6 @@ function onAdsComplete (flags, event) {
 		utils.log('Ads component finished');
 	}
 }
-
-export default {
-	//Permutive trial - config
 	const oPermConf = {
 		'appInfo' : {
 			'appName' : 'article',
@@ -74,8 +71,9 @@ export default {
 		'adsApi' : {
 			'user' : 'https://ads-api.ft.com/v1/user',
 			'content' : 'https://ads-api.ft.com/v1/content/'
-		}
+			}
 	};
+export default {
 	init: (flags, appInfo, opts) => {
 
 		window.addEventListener('ftNextLoaded', function () {

--- a/secret-squirrel.js
+++ b/secret-squirrel.js
@@ -81,7 +81,10 @@ module.exports = {
 			'c225ddde-d85b-11e4-ba53-00144feab7de', // server/test/stubs/navigationv2Data.json:3918|5595
 			'0f3e15c2-dc07-11e6-86ac-f253db7791c6', // server/test/stubs/navigationv2Data.json:3922|5599
 			'/circleci/project/github/RedSparr0w/node', // README.md:1
-			'k=8d2aeb08-16bf-4429-88ff-78f0dca00004' // browser/layout/partials/fastly-insights.html
+			'k=8d2aeb08-16bf-4429-88ff-78f0dca00004', // browser/layout/partials/fastly-insights.html
+			'e1c3fd73-dd41-4abd-b80b-4278d52bf7aa', // Permutive Trial public Api id - remove after trial
+			'b2b3b748-e1f6-4bd5-b2f2-26debc8075a3', // Permutive Trial public key - remove after trial
+			'5cfae92e-6cc5-11e9-80c7-60ee53e6681d' // Permutive Trial content UUID - remove after trial
 		]
 	}
 };


### PR DESCRIPTION
Ads - including Permutive origami component for a trial - all functionality is behind a flag and will not be enabled for real users.

[Permutive](https://developer.permutive.com/) is a Data Management Platform and is being trialed as a replacement for SalesForce DMP (fka Krux). 
The request to run this trial has come from the commercial and ad-operations team.

Permutive would be used for behavioural profiling of users on a website for the purpose of segmenting them for targeting advertising.
This PR is designed to trial the Permutive functionality behind a flag on FT.com; the intention is to enable the functionality only for FT and Permutive devs to ensure that data is being passed end-to-end in the correct way. 
A new origami component has been created, [o-permutive](https://registry.origami.ft.com/components/o-permutive@1.0.0-beta.2/readme?brand=master)  which wraps permutive's client-side code and integrates it with the FT ad-stack. Further details can be found in the origami registry readme.
