### PR TITLE
Remove unused krux monitoring

### DIFF
--- a/components/n-ui/ads/js/ads-metrics.js
+++ b/components/n-ui/ads/js/ads-metrics.js
@@ -32,17 +32,6 @@ const metricsDefinitions = [
 		]
 	},
 	{
-		spoorAction: 'krux',
-		triggers: ['kruxKuidAck', 'kruxKuidError', 'kruxConsentOptinFailed'],
-		marks: [
-			'kruxScriptLoaded',
-			'kruxConsentOptinOK',
-			'kruxConsentOptinFailed',
-			'kruxKuidAck',
-			'kruxKuidError',
-		]
-	},
-	{
 		spoorAction: 'slot-requested',
 		triggers: ['slotGoRender'],
 		marks: [


### PR DESCRIPTION
`krux` was never monitored accurately in `o-ads`. Moreover, `o-ads` is removing all the krux-monitoring-specific events, so this configuration is now useless.

 🐿 v2.12.3

