### PR TITLE
Delegate ads metrics sampling to o-ads

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -22,7 +22,7 @@
     "n-topic-search": "^1.0.3",
     "n-ui-foundations": "^3.0.6",
     "next-session-client": "^2.3.4",
-    "o-ads": "^12.3.0",
+    "o-ads": "^12.3.2",
     "o-permutive": "^1.0.0-beta.3",
     "o-errors": "^3.6.1",
     "o-expander": "^4.4.4",

--- a/bower.json
+++ b/bower.json
@@ -22,7 +22,7 @@
     "n-topic-search": "^1.0.3",
     "n-ui-foundations": "^3.0.6",
     "next-session-client": "^2.3.4",
-    "o-ads": "^12.1.0",
+    "o-ads": "^12.3.0",
     "o-permutive": "^1.0.0-beta.3",
     "o-errors": "^3.6.1",
     "o-expander": "^4.4.4",

--- a/components/n-ui/ads/js/ads-metrics.js
+++ b/components/n-ui/ads/js/ads-metrics.js
@@ -4,21 +4,9 @@ import { utils as oAdsUtils } from 'o-ads';
 // Probability that a page view is chosen to be send ads-related metrics
 const METRICS_SAMPLE_SIZE = 0.1;
 
-let userSendsMetrics;
-
-const inAdsMetricsSample = function () {
-	// We cache the value in order to be consistent with the user
-	// allocation throughout a page view
-	if (typeof userSendsMetrics !== 'undefined') {
-		return userSendsMetrics;
-	}
-
-	userSendsMetrics = (Math.random() < METRICS_SAMPLE_SIZE);
-	return userSendsMetrics;
-};
-
 const metricsDefinitions = [
 	{
+		sampleSize: METRICS_SAMPLE_SIZE,
 		spoorAction: 'page-initialised',
 		triggers: ['serverScriptLoaded'],
 		marks: [
@@ -32,6 +20,7 @@ const metricsDefinitions = [
 		]
 	},
 	{
+		sampleSize: METRICS_SAMPLE_SIZE,
 		spoorAction: 'slot-requested',
 		triggers: ['slotGoRender'],
 		marks: [
@@ -42,6 +31,7 @@ const metricsDefinitions = [
 		multiple: true
 	},
 	{
+		sampleSize: METRICS_SAMPLE_SIZE,
 		spoorAction: 'slot-rendered',
 		triggers: ['slotRenderEnded'],
 		marks: [
@@ -54,9 +44,7 @@ const metricsDefinitions = [
 ];
 
 function sendMetrics (eventPayload) {
-	if (inAdsMetricsSample()) {
-		nUIFoundations.broadcast('oTracking.event', eventPayload);
-	}
+	nUIFoundations.broadcast('oTracking.event', eventPayload);
 }
 
 function setupAdsMetrics () {
@@ -65,7 +53,6 @@ function setupAdsMetrics () {
 
 
 export default {
-	inAdsMetricsSample,
 	sendMetrics,
 	setupAdsMetrics
 };

--- a/components/n-ui/ads/js/ads-metrics.js
+++ b/components/n-ui/ads/js/ads-metrics.js
@@ -12,6 +12,7 @@ const metricsDefinitions = [
 		marks: [
 			'consentBehavioral',
 			'consentProgrammatic',
+			'moatTimeout',
 			'initialising',
 			'IVTComplete',
 			'adsAPIComplete',

--- a/components/n-ui/ads/test/ads-metrics.spec.js
+++ b/components/n-ui/ads/test/ads-metrics.spec.js
@@ -1,6 +1,5 @@
 /* globals describe, it, expect, sinon */
 import nUIFoundations from 'n-ui-foundations';
-import AdsMetrics from '../js/ads-metrics';
 import { sendMetrics } from '../js/ads-metrics';
 
 let sandbox;
@@ -15,25 +14,9 @@ describe('Ads Metrics', () => {
 	});
 
 	it('sendMetrics should call broadcast with the right params if user is in metrics sample', () => {
-		const inMetricsSampleStub = sandbox.stub().callsFake(() => true);
-		AdsMetrics.__Rewire__('inAdsMetricsSample', inMetricsSampleStub);
 		const broadcastStub = sandbox.stub(nUIFoundations, 'broadcast');
 		const eventPayload = { a: 'aa', b: 'bb' };
 		sendMetrics(eventPayload);
-		expect(inMetricsSampleStub).to.have.been.called;
 		expect(broadcastStub).to.have.been.calledWith('oTracking.event', eventPayload);
-		AdsMetrics.__ResetDependency__('inAdsMetricsSample');
-	});
-
-	it('Should return the same value for inAdsMetricsSample when called multiple times', () => {
-		const firstValue = AdsMetrics.inAdsMetricsSample();
-
-		let count = 0;
-		for (let i = 0; i < 100; i++) {
-			if (AdsMetrics.inAdsMetricsSample() === firstValue) {
-				count++;
-			}
-		}
-		expect(count).to.equal(100);
 	});
 });


### PR DESCRIPTION
This updates `o-ads` to the latest version while delegating the ads monitoring sampling functionality to `o-ads` and adding a new additional metric to the `'page-initialised` Spoor action. 