### PR TITLE
Improve the accessibility of current page links

### DIFF
--- a/components/n-ui/header/partials/drawer/template.html
+++ b/components/n-ui/header/partials/drawer/template.html
@@ -1,6 +1,6 @@
 {{#*inline "DrawerParentItem"}}
 	<div class="o-header__drawer-menu-toggle-wrapper">
-		<a class="o-header__drawer-menu-link o-header__drawer-menu-link--parent o-header__drawer-menu-link--{{#if selected}}selected{{else}}unselected{{/if}}" href="{{url}}" {{#if selected}}aria-label="Current page" aria-current="true"{{/if}} data-trackable="{{label}}">{{label}}</a>
+		<a class="o-header__drawer-menu-link o-header__drawer-menu-link--parent o-header__drawer-menu-link--{{#if selected}}selected{{else}}unselected{{/if}}" href="{{url}}" {{#if selected}}aria-label="{{label}}, current page" aria-current="page"{{/if}} data-trackable="{{label}}">{{label}}</a>
 		<button class="o-header__drawer-menu-toggle o-header__drawer-menu-toggle--{{#if selected}}selected{{else}}unselected{{/if}}" aria-controls="o-header-drawer-child-{{@index}}" data-trackable="sub-level-toggle | {{label}}">
 			Show more {{label}} links
 		</button>
@@ -8,18 +8,18 @@
 	<ul class="o-header__drawer-menu-list o-header__drawer-menu-list--child" id="o-header-drawer-child-{{@index}}" data-trackable="sub-level">
 		{{#each submenu.items}}
 		<li class="o-header__drawer-menu-item">
-			<a class="o-header__drawer-menu-link o-header__drawer-menu-link--child o-header__drawer-menu-link--{{#if selected}}selected{{else}}unselected{{/if}}" href="{{url}}" {{#if selected}}aria-label="Current page" aria-current="true"{{/if}} data-trackable="{{label}}">{{label}}</a>
+			<a class="o-header__drawer-menu-link o-header__drawer-menu-link--child o-header__drawer-menu-link--{{#if selected}}selected{{else}}unselected{{/if}}" href="{{url}}" {{#if selected}}aria-label="{{label}}, current page" aria-current="page"{{/if}} data-trackable="{{label}}">{{label}}</a>
 		</li>
 		{{/each}}
 	</ul>
 {{/inline}}
 
 {{#*inline "DrawerSingleItem"}}
-	<a class="o-header__drawer-menu-link o-header__drawer-menu-link--{{#if selected}}selected{{else}}unselected{{/if}}" href="{{url}}" {{#if selected}}aria-label="Current page" aria-current="true"{{/if}} data-trackable="{{label}}">{{label}}</a>
+<a class="o-header__drawer-menu-link o-header__drawer-menu-link--{{#if selected}}selected{{else}}unselected{{/if}}" href="{{url}}" {{#if selected}}aria-label="{{label}}, current page" aria-current="page"{{/if}} data-trackable="{{label}}">{{label}}</a>
 {{/inline}}
 
 {{#*inline "DrawerSpecialItem"}}
-	<a class="o-header__drawer-menu-link o-header__drawer-menu-link--secondary o-header__drawer-menu-link--{{#if selected}}selected{{else}}unselected{{/if}}" href="{{url}}" {{#if selected}}aria-label="Current page" aria-current="true"{{/if}} data-trackable="{{label}}">{{label}}</a>
+<a class="o-header__drawer-menu-link o-header__drawer-menu-link--secondary o-header__drawer-menu-link--{{#if selected}}selected{{else}}unselected{{/if}}" href="{{url}}" {{#if selected}}aria-label="{{label}}, current page" aria-current="page"{{/if}} data-trackable="{{label}}">{{label}}</a>
 {{/inline}}
 
 <div class="o-header__drawer" id="o-header-drawer" role="navigation" aria-label="Drawer menu" data-o-header-drawer data-o-header-drawer--no-js data-trackable="drawer" data-trackable-terminate>


### PR DESCRIPTION
We updated `aria-current` from `true` to `page` to align with the spec https://www.w3.org/TR/wai-aria-1.1/#aria-current

We have also updated the `aria-label` to include the page label as
voiceover was just announcing "Current Page" and will now announce
"Home, current page".


## Before
![Screenshot of voiceover on ft draw menu before accessibility change](https://user-images.githubusercontent.com/524573/58317722-4bed5e00-7e0e-11e9-9edb-3db7dd7df089.png)


## After
![Screenshot of voiceover on ft draw menu after accessibility change](https://user-images.githubusercontent.com/524573/58317730-527bd580-7e0e-11e9-8248-aef34ab1abf2.png)

