### PR TITLE
floodlight should now work with both next-subscribe and next-signup

### DIFF
--- a/components/n-ui/tracking/third-party/floodlight.js
+++ b/components/n-ui/tracking/third-party/floodlight.js
@@ -9,8 +9,8 @@ module.exports = function (flags) {
 	const $trial = document.querySelector('[data-signup-is-trial]');
 
 	// sign-up funnel flags
-	const isSignUpForm = /^\/signup/.test(location.pathname);
-	const isSubscriptionConfirmation = /^\/thank-you/.test(location.pathname);
+	const isSignUpForm = /^\/signup/.test(location.pathname) || /^\/buy\/offer/.test(location.pathname);
+	const isSubscriptionConfirmation = /^\/thank-you/.test(location.pathname) || /^\/buy\/offer\/[^/]+\/confirmation$/.test(location.pathname);
 	const isTrialConfirmation = ($trial) ? $trial.getAttribute('data-signup-is-trial') === 'true' : undefined;
 	const isBarrier = !!document.querySelector('[data-trackable="page:product"]');
 	const isSubscriber = window.FT.flags.subscriberCohort;


### PR DESCRIPTION
Marketing pixel (floodlight) was not working on the new conversion buy flow form (next-subscribe).
The old flow (next-signup) and the new one use different urls, n-ui will now support both.

 🐿 v2.12.3