### PR TITLE
Receive barrier tracking properties in a single object rather than in multiple variables

### DIFF
--- a/components/n-ui/tracking/ft/index.js
+++ b/components/n-ui/tracking/ft/index.js
@@ -5,10 +5,6 @@ const nextEvents = require('./next-events');
 const abTestHelpers = require('./utils/abTestHelpers');
 const broadcast = require('n-ui-foundations').broadcast;
 
-function nodesToArray (nodelist) {
-	return [].slice.call(nodelist);
-}
-
 function getRootData (name) {
 	return document.documentElement.getAttribute(`data-${name}`);
 }
@@ -57,7 +53,7 @@ const oTrackingWrapper = {
 
 			const errorStatus = (/nextErrorStatus=(\d{3})/.exec(window.location.search) || [])[1];
 			const errorReason = (/nextErrorReason=(\w+)/.exec(window.location.search) || [])[1];
-			const pageViewConf = {context: {}};
+			const pageViewConf = { context: {} };
 
 			if (getRootData('content-type') === 'podcast' || getRootData('content-type') === 'audio') {
 				pageViewConf.context.content = {
@@ -132,7 +128,6 @@ const oTrackingWrapper = {
 
 			// barriers
 			let barrierType = document.querySelector('[data-barrier]');
-			let productSelectorFlag = document.querySelector('[data-barrier-is-product-selector]');
 
 			if (barrierType) {
 				pageViewConf.context.barrier = true;
@@ -141,36 +136,17 @@ const oTrackingWrapper = {
 
 			// FIXME - should not fire on barriers, but needs to be around for a while data analytics fix their SQL
 			// Page view must not be triggered in any form of frameset, only a genuine page view, or the error page domain, as error pages are served in iframes.
-			if(window === window.top || window.location.hostname === 'errors-next.ft.com') {
+			if (window === window.top || window.location.hostname === 'errors-next.ft.com') {
 				oTracking.page(pageViewConf.context);
 			}
 
 			if (barrierType) {
-
-				const isProductSelector = (productSelectorFlag) ? productSelectorFlag.getAttribute('data-barrier-is-product-selector') === 'true' : false;
-
-				// https://docs.google.com/document/d/18_yV2s813XCrBF7w6196FLhLJzWXK4hXT2sIpDZVvhQ/edit?ts=575e9368#
-				const opportunity = {
-					type: (isProductSelector) ? 'products' : 'barrier',
-					subtype: barrierType.getAttribute('data-opportunity-subtype') || barrierType.getAttribute('data-barrier')
-				};
-
-				const offers = document.querySelectorAll('[data-offer-id]');
-				const acquisitionContext = document.querySelectorAll('[data-acquisition-context]');
-				const messaging = barrierType.getAttribute('data-barrier-messaging');
-
-				const barrierReferrer = (/barrierReferrer=(\w+)/.exec(window.location.search) || [])[1];
+				const customTracking = JSON.parse(barrierType.getAttribute('data-tracking-object'));
 
 				broadcast('oTracking.event', Object.assign({
 					category: 'barrier',
-					action: 'view',
-					opportunity: opportunity,
-					barrierReferrer: barrierReferrer,
-					type: barrierType.getAttribute('data-barrier'),
-					commsType: messaging,
-					acquisitionContext: nodesToArray(acquisitionContext).map(e => e.getAttribute('data-acquisition-context')),
-					offers: nodesToArray(offers).map(e => e.getAttribute('data-offer-id'))
-				}, context));
+					action: 'view'
+				}, context, customTracking));
 			}
 
 		} catch (err) {


### PR DESCRIPTION
This is the first step to moving tracking for barriers out of `n-ui`. This moves the computation of tracking values into next-product and sends them as one object to `n-ui` for attaching to an `o-tracking` event. 

We are doing this work now as enhancements to barrier tracking have been requested by the data analytics team and rather than 'pollute' `n-ui` with more custom barrier tracking we are moving it out as much as possible to `next-product`.

Additional work is required at a later stage to send this event directly from `next-product` but is not being done right now as it involves updating tracking code for the standalone barrier in the `epaper` repo which is also using the `n-ui` barrier tracking code at the moment.

Once that additional work has been done, the associated file in `n-tracking` will not be needed (FYI @ifeanyiisitor and @i-like-robots, we will keep you up to date with that) - https://github.com/Financial-Times/n-tracking/blob/b848cdfb1dacf3be841dfc0407ab8154c19af9d6/src/trackers/barrier-view-tracking.js

The PR for the work in `next-product` is here - https://github.com/Financial-Times/next-product/pull/742. The `next-product` PR must be merged before the `n-ui` PR.

The associated Trello card for this work is here - https://trello.com/c/YLZER8cN