### PR TITLE
Support new adsmetricsflag

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -22,7 +22,7 @@
     "n-topic-search": "^1.0.3",
     "n-ui-foundations": "^3.0.6",
     "next-session-client": "^2.3.4",
-    "o-ads": "^12.3.2",
+    "o-ads": "^12.4.1",
     "o-permutive": "^v1.0.1",
     "o-errors": "^3.6.1",
     "o-expander": "^4.4.4",

--- a/components/n-ui/ads/index.js
+++ b/components/n-ui/ads/index.js
@@ -18,7 +18,7 @@ window.oAds = Ads;
 function initOAds (flags, appName, adOptions) {
 	const initObj = oAdsConfig(flags, appName, adOptions);
 
-	setupAdsMetrics();
+	setupAdsMetrics(flags && flags.adsDisableMetricsSampling);
 
 	utils.log('dfp_targeting', initObj.dfp_targeting);
 	onAdsCompleteCallback = onAdsComplete.bind(this, flags);

--- a/components/n-ui/ads/js/ads-metrics.js
+++ b/components/n-ui/ads/js/ads-metrics.js
@@ -48,8 +48,8 @@ function sendMetrics (eventPayload) {
 	nUIFoundations.broadcast('oTracking.event', eventPayload);
 }
 
-function setupAdsMetrics () {
-	oAdsUtils.setupMetrics(metricsDefinitions, sendMetrics);
+function setupAdsMetrics (disableSampling) {
+	oAdsUtils.setupMetrics(metricsDefinitions, sendMetrics, disableSampling);
 }
 
 

--- a/components/n-ui/ads/test/index.spec.js
+++ b/components/n-ui/ads/test/index.spec.js
@@ -57,11 +57,14 @@ describe('Main', () => {
 	});
 
 	it('Should setup ads monitoring functionality', () => {
-		const flags = { get: () => true };
+		const flags = {
+			get: () => true,
+			adsDisableMetricsSampling: true
+		};
 		const setupMetricsStub = sandbox.stub(AdsMetrics, 'setupAdsMetrics');
 
 		return main.init(flags, { name: 'article' }).then(() => {
-			expect(setupMetricsStub).to.have.been.called;
+			expect(setupMetricsStub).to.have.been.calledWith(true);
 		});
 	});
 });


### PR DESCRIPTION
Adds support for the new `adsDisableMetricsSampling` flag which overrides the hardcoded sampling configuration for ads metrics.

For more information on how this works, see [o-ads docs](https://financial-times.github.io/o-ads/docs/developer-guide/advanced-display#setupmetrics).