### PR TITLE
Improve ads metrics

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -22,7 +22,7 @@
     "n-topic-search": "^1.0.3",
     "n-ui-foundations": "^3.0.6",
     "next-session-client": "^2.3.4",
-    "o-ads": "^12.4.1",
+    "o-ads": "^12.5.0",
     "o-permutive": "^v1.0.1",
     "o-errors": "^3.6.1",
     "o-expander": "^4.4.4",

--- a/components/n-ui/ads/js/ads-metrics.js
+++ b/components/n-ui/ads/js/ads-metrics.js
@@ -38,8 +38,15 @@ const metricsDefinitions = [
 		marks: [
 			'slotRenderStart',
 			'slotExpand',
-			'slotRenderEnded',
+			'slotRenderEnded'
 		],
+		multiple: true
+	},
+	{
+		sampleSize: METRICS_SAMPLE_SIZE,
+		spoorAction: 'slot-collapsed',
+		triggers: ['slotCollapsed'],
+		marks: [ 'slotCollapsed' ],
 		multiple: true
 	}
 ];


### PR DESCRIPTION
This change adds:

1) `o-ads v12.5.0` which includes the `creativeID` in all ads metrics for which it is available.
2) Track the new `slotCollapsed` event added in `o-ads 12.5.0`


🐿 v2.12.3