### PR TITLE
add an inline comment to discourage bumping focus-visible version

### DIFF
--- a/browser/js/app-initializer.js
+++ b/browser/js/app-initializer.js
@@ -11,6 +11,10 @@ import feedback from 'n-feedback';
 import { perfMark } from 'n-ui-foundations';
 
 //Polyfill for :focus-visible https://github.com/WICG/focus-visible
+// NOTE: v5 of this polyfill with shadow DOM implementation is not yet supported by o-normalise
+// https://github.com/WICG/focus-visible/pull/196/files
+// https://github.com/Financial-Times/o-normalise/issues/41
+
 import 'focus-visible';
 
 export const presets = {


### PR DESCRIPTION
Adds a comment to caution that the latest version of the focus-visible polyfill has breaking changes which don't work with o-normalise in its current form. We should avoid bumping this dependency until the related origami issue has been closed https://github.com/Financial-Times/o-normalise/issues/41

https://github.com/WICG/focus-visible/pull/196/files

🐿 v2.12.3
