### PR TITLE
Add domInteractive metric to ads monitoring

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -22,7 +22,7 @@
     "n-topic-search": "^1.0.3",
     "n-ui-foundations": "^3.0.6",
     "next-session-client": "^2.3.4",
-    "o-ads": "^12.6.0",
+    "o-ads": "^12.7.0",
     "o-permutive": "^v1.0.1",
     "o-errors": "^3.6.1",
     "o-expander": "^4.4.4",

--- a/components/n-ui/ads/js/ads-metrics.js
+++ b/components/n-ui/ads/js/ads-metrics.js
@@ -18,7 +18,8 @@ const metricsDefinitions = [
 			'adsAPIComplete',
 			'initialised',
 			'serverScriptLoaded',
-		]
+		],
+		navigation: ['domInteractive']
 	},
 	{
 		sampleSize: METRICS_SAMPLE_SIZE,


### PR DESCRIPTION
Update to `o-ads 12.7.0` and add `domInteractive` metric to ads monitoring.
 
🐿 v2.12.4