### PR TITLE
Add barrier type back to page:view event

### DIFF
--- a/components/n-ui/tracking/ft/index.js
+++ b/components/n-ui/tracking/ft/index.js
@@ -126,6 +126,12 @@ const oTrackingWrapper = {
 				pageViewConf.context['teaser_tests'] = abTestHelpers.getTeaserTestContext(document);
 			}
 
+			// Barriers - We need to keep this here because the data team relies on the barrier type being on the page:view event.
+			let barrierType = document.querySelector('[data-barrier]');
+			if (barrierType) {
+				pageViewConf.context.barrierType = barrierType.getAttribute('data-barrier');
+			};
+
 			// FIXME - should not fire on barriers, but needs to be around for a while data analytics fix their SQL
 			// Page view must not be triggered in any form of frameset, only a genuine page view, or the error page domain, as error pages are served in iframes.
 			if (window === window.top || window.location.hostname === 'errors-next.ft.com') {


### PR DESCRIPTION
I recommended pulling this data from the `barrier:view` event which has this info, but got the following reply from Chris Brown:

> The barrier:view event is being captured by Data Platform so this is indeed available for reporting.  However the processing of the different events are independent of each other, so that the content_barrier field on the page view can't be populated by the barrier:view event.  The barrier:view event could be joined to the page:view event in SQL but that will involve modifying a lot of existing SQLin reports and in existing dashboards.
>
> In addition the "counted" flag is set to false by the presence of the barrier properties on the page:view, so we will be counting barriers as conent views for B2B in Enterprise Tools/Lighthouse.
>
> So there would be a lot of work needed to change how the barriers are reported.

🐿 v2.12.3

<!-- 😭 -->