### PR TITLE
Upgrade o-header to ^7.8.10

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -27,7 +27,7 @@
     "o-errors": "^3.6.1",
     "o-expander": "^4.4.4",
     "o-footer": "^6.0.10",
-    "o-header": "^7.8.4",
+    "o-header": "^7.8.10",
     "o-tracking": "^1.4.1",
     "logo-images": "^1.6.0",
     "n-feedback": "^4.1.1"


### PR DESCRIPTION
It appears Next's critical CSS generator is 
[not including o-header margin correctly](https://github.com/Financial-Times/o-header/pull/336#issuecomment-507298560). 

As a workaround, [o-header@^7.8.10](https://github.com/Financial-Times/o-header/pull/340) uses 
the long form `margin-left` and `margin-right`, 
until we find the root of the issue.