### PR TITLE
Hide right signed-in nav if accountNavOnMyft flag is enabled

### DIFF
--- a/components/n-ui/header/partials/header/nav.html
+++ b/components/n-ui/header/partials/header/nav.html
@@ -37,11 +37,13 @@
 					</li>
 					{{/with}}
 				{{else}}
-					{{#each @root.navigation.menus.navbar-right.items}}
-						<li class="o-header__nav-item">
-							<a class="o-header__nav-link" href="{{url}}" data-trackable="{{label}}">{{label}}</a>
-						</li>
-					{{/each}}
+					{{#unless @root.flags.accountNavOnMyft}}
+						{{#each @root.navigation.menus.navbar-right.items}}
+							<li class="o-header__nav-item">
+								<a class="o-header__nav-link" href="{{url}}" data-trackable="{{label}}">{{label}}</a>
+							</li>
+						{{/each}}
+					{{/unless}}
 				{{/if}}
 			</ul>
 		{{/unlessEquals}}


### PR DESCRIPTION
So that we can AB test moving this menu to the myFT nav

![image](https://user-images.githubusercontent.com/8417658/61543968-5b6adb00-aa3c-11e9-8970-0ffb01f147c2.png)

Trello: https://trello.com/c/JUv9Nihw/3612-ab-test-moving-account-settings-and-portfolio-links-to-end-of-myft-nav

See also: https://github.com/Financial-Times/next-myft-page/pull/2077

 🐿 v2.12.4