### PR TITLE
Ensuring that the permutive User Identify function does not run if us…

### DIFF
--- a/components/n-ui/ads/index.js
+++ b/components/n-ui/ads/index.js
@@ -72,7 +72,9 @@ export default {
 								};
 
 								oPermutive.setPageMetaData(metaData);
-								oPermutive.identifyUser(userIdent);
+								if (typeof userIdent.guid !== 'undefined') {
+									oPermutive.identifyUser(userIdent);
+								}
 							}
 						})
 						// krux

--- a/components/n-ui/ads/js/oPermutiveConfig.js
+++ b/components/n-ui/ads/js/oPermutiveConfig.js
@@ -38,14 +38,14 @@ export function getOPermutiveMetaData (appName, kruxMeta, contentId = null) {
 			const type = Array.isArray(kruxPageMeta.genre) && kruxPageMeta.genre.length > 0 ? kruxPageMeta.genre[0] : null;
 
 			pageMeta = {
-					id: contentId,
-					type: type,
-					organisations: kruxPageMeta.organisations,
-					people: kruxPageMeta.people,
-					categories: kruxPageMeta.ca,
-					authors: kruxPageMeta.authors,
-					topics: kruxPageMeta.topics,
-					admants: kruxPageMeta.ad
+				id: contentId,
+				type: type,
+				organisations: kruxPageMeta.organisations,
+				people: kruxPageMeta.people,
+				categories: kruxPageMeta.ca,
+				authors: kruxPageMeta.authors,
+				topics: kruxPageMeta.topics,
+				admants: kruxPageMeta.ad
 			};
 		}
 	}


### PR DESCRIPTION
Ads -Permutive, ensuring that we check that we have a user-guid before calling Permutive's User Identity function.