### PR TITLE
Temporarly Remove Coveralls from CircleCI builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,15 +48,7 @@ test-server: export NODE_ENV=production
 test-server: export HOSTEDGRAPHITE_APIKEY=dummykey
 test-server: export FT_GRAPHITE_KEY=test-graphite-key
 test-server: copy-stylesheet-partial
-ifneq ($(CIRCLECI),)
-ifeq ($(CIRCLE_TAG),)
-	make test-server-coverage && cat ./coverage/lcov.info | ./node_modules/.bin/coveralls
-else
 	make test-server-plain
-endif
-else
-	make test-server-plain
-endif
 
 test-server-plain:
 	mocha --exit --file server/test/setup.js server/test/*.test.js server/test/**/*.test.js


### PR DESCRIPTION
Coveralls has been down for more than a day and is blocking deployments. 
See also https://github.com/Financial-Times/next-front-page/pull/2070
 🐿 v2.12.4