### PR TITLE
 Update footer section title markup for a11y

### DIFF
--- a/components/n-ui/footer/partials/menu/template.html
+++ b/components/n-ui/footer/partials/menu/template.html
@@ -3,9 +3,9 @@
 		{{#each @root.navigation.menus.footer.items}}
 		{{#if submenu}}
 		<div class="o-footer__matrix-group o-footer__matrix-group--{{submenu.items.length}}">
-			<div class="o-footer__matrix-title" {{#ifEquals submenu.items.length 2}}aria-controls="o-footer-section-{{@index}}"{{/ifEquals}}>
+			<h2 class="o-footer__matrix-title" {{#ifEquals submenu.items.length 2}}aria-controls="o-footer-section-{{@index}}"{{/ifEquals}}>
 			{{{label}}}
-		</div>
+			</h2>
 		<div class="o-footer__matrix-content" id="o-footer-section-{{@index}}">
 			{{#each submenu.items}}
 			<div class="o-footer__matrix-column">

--- a/components/n-ui/footer/partials/menu/template.html
+++ b/components/n-ui/footer/partials/menu/template.html
@@ -1,11 +1,12 @@
 <div class="o-footer__row">
+	<h2 class="o-normalise-visually-hidden">Useful links</h2>
 	<nav class="o-footer__matrix" role="navigation" aria-label="Useful links">
 		{{#each @root.navigation.menus.footer.items}}
 		{{#if submenu}}
 		<div class="o-footer__matrix-group o-footer__matrix-group--{{submenu.items.length}}">
-			<h2 class="o-footer__matrix-title" {{#ifEquals submenu.items.length 2}}aria-controls="o-footer-section-{{@index}}"{{/ifEquals}}>
+			<h3 class="o-footer__matrix-title" {{#ifEquals submenu.items.length 2}}aria-controls="o-footer-section-{{@index}}"{{/ifEquals}}>
 			{{{label}}}
-			</h2>
+			</h3>
 			<div class="o-footer__matrix-content" id="o-footer-section-{{@index}}">
 				{{#each submenu.items}}
 				<div class="o-footer__matrix-column">

--- a/components/n-ui/footer/partials/menu/template.html
+++ b/components/n-ui/footer/partials/menu/template.html
@@ -6,21 +6,21 @@
 			<h2 class="o-footer__matrix-title" {{#ifEquals submenu.items.length 2}}aria-controls="o-footer-section-{{@index}}"{{/ifEquals}}>
 			{{{label}}}
 			</h2>
-		<div class="o-footer__matrix-content" id="o-footer-section-{{@index}}">
-			{{#each submenu.items}}
-			<div class="o-footer__matrix-column">
-				{{#each this}}
-				<a class="o-footer__matrix-link" href="{{url}}" data-trackable="{{label}}" {{#disableTracking}}data-o-tracking-do-not-track="true"{{/disableTracking}}>{{{label}}}</a>
+			<div class="o-footer__matrix-content" id="o-footer-section-{{@index}}">
+				{{#each submenu.items}}
+				<div class="o-footer__matrix-column">
+					{{#each this}}
+					<a class="o-footer__matrix-link" href="{{url}}" data-trackable="{{label}}" {{#disableTracking}}data-o-tracking-do-not-track="true"{{/disableTracking}}>{{{label}}}</a>
+					{{/each}}
+				</div>
 				{{/each}}
 			</div>
-			{{/each}}
 		</div>
-</div>
-{{/if}}
-{{/each}}
-</nav>
+		{{/if}}
+		{{/each}}
+	</nav>
 
-<div class="o-footer__external-link o-footer__matrix-title">
-	<a class="o-footer__more-from-ft o-footer__matrix-title" href="http://ft.com/more-from-ft-group" data-trackable="more-from-ft">More from the FT Group</a>
-</div>
+	<div class="o-footer__external-link o-footer__matrix-title">
+		<a class="o-footer__more-from-ft o-footer__matrix-title" href="http://ft.com/more-from-ft-group" data-trackable="more-from-ft">More from the FT Group</a>
+	</div>
 </div>


### PR DESCRIPTION
DAC_Headings_Issue1 suggests that footer section titles should be h2.