### PR TITLE
Fix hierarchy for pa11y

### DIFF
--- a/components/n-ui/footer/partials/menu/template.html
+++ b/components/n-ui/footer/partials/menu/template.html
@@ -1,12 +1,12 @@
 <div class="o-footer__row">
-	<h2 class="o-normalise-visually-hidden">Useful links</h2>
+	<h1 class="o-normalise-visually-hidden">Useful links</h1>
 	<nav class="o-footer__matrix" role="navigation" aria-label="Useful links">
 		{{#each @root.navigation.menus.footer.items}}
 		{{#if submenu}}
 		<div class="o-footer__matrix-group o-footer__matrix-group--{{submenu.items.length}}">
-			<h3 class="o-footer__matrix-title" {{#ifEquals submenu.items.length 2}}aria-controls="o-footer-section-{{@index}}"{{/ifEquals}}>
+			<h2 class="o-footer__matrix-title" {{#ifEquals submenu.items.length 2}}aria-controls="o-footer-section-{{@index}}"{{/ifEquals}}>
 			{{{label}}}
-			</h3>
+			</h2>
 			<div class="o-footer__matrix-content" id="o-footer-section-{{@index}}">
 				{{#each submenu.items}}
 				<div class="o-footer__matrix-column">


### PR DESCRIPTION
Recent changes to the footer were causing pa11y to complain. This meant that apps using n-ui were not possible to deploy through CircleCI.

Example of pa11y error:

```
Errors in https://ft-next-myft-alex-fix-c-l909sy.herokuapp.com/myft/confirm/6ccc5a3f-ebb5-4f3b-962a-bd3ce35cae20/put-followed/?conceptName=whatever:

 • The heading structure is not logically nested. This h2 element appears to be
   the primary document heading, so should be an h1 element.

   (#site-footer > div:nth-child(1) > div:nth-child(1) > h2)

   <h2 class="o-normalise-visually-hidden">Useful links</h2>
```

Fix is to change `h2` to `h1` and `h3` to `h2`.

Testing in browser dev tools HTML editor, and changing these tags make no difference to appearance, since style is done with classes.

See also: https://github.com/Financial-Times/n-ui/pull/1483#issuecomment-523008493

 🐿 v2.12.4