### PR TITLE
ADSDEV-189 - Add Google Tag Manager behind a flag

### DIFF
--- a/browser/layout/partials/gtm-body.html
+++ b/browser/layout/partials/gtm-body.html
@@ -1,3 +1,1 @@
-<!-- Google Tag Manager (noscript) -->
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-NWQJW68" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-<!-- End Google Tag Manager (noscript) -->

--- a/browser/layout/partials/gtm-body.html
+++ b/browser/layout/partials/gtm-body.html
@@ -1,1 +1,5 @@
+{{#if @root.flags.enableGTM}}
+<!-- Google Tag Manager (noscript) -->
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-NWQJW68" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<!-- End Google Tag Manager (noscript) -->
+{{/if}}

--- a/browser/layout/partials/gtm-body.html
+++ b/browser/layout/partials/gtm-body.html
@@ -1,0 +1,3 @@
+<!-- Google Tag Manager (noscript) -->
+<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-NWQJW68" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<!-- End Google Tag Manager (noscript) -->

--- a/browser/layout/partials/gtm-head.html
+++ b/browser/layout/partials/gtm-head.html
@@ -1,7 +1,5 @@
-<!-- Google Tag Manager -->
 <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
 new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
 j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
 })(window,document,'script','dataLayer','GTM-NWQJW68');</script>
-<!-- End Google Tag Manager -->

--- a/browser/layout/partials/gtm-head.html
+++ b/browser/layout/partials/gtm-head.html
@@ -1,0 +1,7 @@
+<!-- Google Tag Manager -->
+<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','GTM-NWQJW68');</script>
+<!-- End Google Tag Manager -->

--- a/browser/layout/partials/gtm-head.html
+++ b/browser/layout/partials/gtm-head.html
@@ -1,5 +1,9 @@
+{{#if @root.flags.enableGTM}}
+<!-- Google Tag Manager -->
 <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
 new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
 j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
 })(window,document,'script','dataLayer','GTM-NWQJW68');</script>
+<!-- End Google Tag Manager -->
+{{/if}}

--- a/browser/layout/vanilla.html
+++ b/browser/layout/vanilla.html
@@ -15,14 +15,20 @@
 		{{/if}}
 		{{>layout/partials/env-setup}}
 		{{>layout/partials/stylesheets}}
+		{{>layout/partials/gtm-head}}
 
 		{{#outputBlock 'head'}}{{/outputBlock}}
 		<script>
 			{{>layout/partials/ctm}}
 			{{>layout/partials/enhance-fonts}}
 		</script>
+
+
+
+
 	</head>
 	<body class="o-hoverable-on" data-next-is-logged-in="{{@root.anon.userIsLoggedIn}}" data-trackable="page:{{@root.__name}}{{#if @root.trackablePageName}}/{{@root.trackablePageName}}{{/if}}">
+		{{>layout/partials/gtm-body}}
 		{{{body}}}
 		{{>layout/partials/bootstrapper}}
 		{{#if @root.flags.fastlyInsights}}

--- a/browser/layout/wrapper.html
+++ b/browser/layout/wrapper.html
@@ -107,6 +107,7 @@
 		{{#if @root.flags.adsInizioSurvey}}
 			<script async src="https://cdn.brandmetrics.com/survey/script/45b903c6675b4a9b85db13385a3d6084.js"></script>
 		{{/if}}
+		{{>layout/partials/gtm-head}}
 		{{#if @root.flags.floodlight}}
 			<!-- Global site tag (gtag.js) - Google Marketing Platform -->
 			<script async src="https://www.googletagmanager.com/gtag/js?id=DC-9073629"></script>
@@ -120,6 +121,7 @@
 		{{/if}}
 	</head>
 	<body data-next-is-logged-in="{{@root.anon.userIsLoggedIn}}" data-trackable="page:{{@root.__name}}{{#if @root.trackablePageName}}/{{@root.trackablePageName}}{{/if}}">
+		{{>layout/partials/gtm-body}}
 		{{#if withGcs}}
 			<script type="text/javascript">
 				var triggerGoogleCustomerSurvey = function(articleUrl, contentId) {


### PR DESCRIPTION
This adds the Google Tag Manager to the site behind a new flag. 

I have added it to both the `wrapper` and the `vanilla` templates, although only the `wrapper` template seems to be in use at the moment.

It's worth mentioning that this PR is not trying to address the following:

1) Any script that is currently being added to the site via n-ui code will be included twice if added via GTM.
2) Changes made via GTM don't trigger any CI workflow that can prevent us from going live with something breaks our builds*. 

*I have [already experienced](https://circleci.com/gh/Financial-Times/n-ui/9234) how a malformed tag in GTM can break a n-ui build and this wouldn't be immediately noticed by any developer.