### PR TITLE
rename "Companies" in menu to "Business".

### DIFF
--- a/server/models/navigation/navigationModelV2.js
+++ b/server/models/navigation/navigationModelV2.js
@@ -132,7 +132,7 @@ module.exports = class NavigationModelV2 {
 				NavigationModelV2.decorateSelected(menuData, currentUrl);
 			}
 
-			if( res.locals.flags.renameCompaniesToBusiness ) {
+			if( res.locals.flags && res.locals.flags.renameCompaniesToBusiness ) {
 				renameCompaniesToBusiness(menuData);
 			}
 

--- a/server/models/navigation/navigationModelV2.js
+++ b/server/models/navigation/navigationModelV2.js
@@ -16,6 +16,22 @@ const menuNameMap = new Map([
 
 const clone = obj => JSON.parse(JSON.stringify(obj));
 
+// Function to support the A/B test of renaming the "Companies" section to "Business"
+// This function can be removed once the test is complete.
+function renameCompaniesToBusiness( obj ) {
+	if( Array.isArray(obj) ) {
+		obj.forEach(renameCompaniesToBusiness);
+	} else if( obj ) {
+		if( obj.label ) {
+			obj.label = obj.label.replace(/Companies/, 'Business');
+		}
+		renameCompaniesToBusiness(obj.items);
+		renameCompaniesToBusiness(obj.data);
+		renameCompaniesToBusiness(obj.submenu);
+		renameCompaniesToBusiness(obj.meganav);
+	}
+}
+
 module.exports = class NavigationModelV2 {
 
 	constructor (options){
@@ -114,6 +130,10 @@ module.exports = class NavigationModelV2 {
 
 			if(menuData && menuData !== 'footer'){
 				NavigationModelV2.decorateSelected(menuData, currentUrl);
+			}
+
+			if( res.locals.flags.renameCompaniesToBusiness ) {
+				renameCompaniesToBusiness(menuData);
 			}
 
 			res.locals.navigation.menus[menuName] = menuData;


### PR DESCRIPTION
Changes the word "Companies" in the menus to "Business" in

- main nav menu heading
- main nav menu item "Companies home"
- drawer (burger) menu top level item

This is for an AB test only. **It is not intended as a permanent solution** since it rewrites data from an external source, making assumptions about the structure and content of that data.

The proper solution is to change the menu data in [origami-navigation-data](https://github.com/Financial-Times/origami-navigation-data), but doing so is hard to set up as an AB test since `flags` are not available.

![image](https://user-images.githubusercontent.com/8417658/64180374-94c8a000-ce5c-11e9-80a6-2aca4458c0e1.png)

Trello: https://trello.com/c/Sapj96OC/3635-set-up-ab-test-for-changing-companies-section-to-business

See also: https://github.com/Financial-Times/next-stream-page/pull/2209
