### PR TITLE
Upgrade o-ads to v13.1

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -22,7 +22,7 @@
     "n-topic-search": "^1.0.3",
     "n-ui-foundations": "^3.0.6",
     "next-session-client": "^2.3.4",
-    "o-ads": "^12.8.0",
+    "o-ads": "^13.1.0",
     "o-permutive": "^v1.0.3",
     "o-errors": "^3.6.1",
     "o-expander": "^4.4.4",

--- a/components/n-ui/ads/test/oAdsConfig.spec.js
+++ b/components/n-ui/ads/test/oAdsConfig.spec.js
@@ -58,30 +58,6 @@ describe('Config', () => {
 			expect(config.gpt.rendering).not.to.be.ok;
 		});
 
-		it('Should set krux configuration when flag is set to false', () => {
-			const flags = { get: () => true };
-			document.cookie = 'FT_U=EID=1234_PID=abc';
-			const config = oAdsConfig(flags, 'article' );
-
-			expect(config.krux.id).to.be.ok;
-			expect(config.krux.attributes).to.be.ok;
-			expect(config.krux.attributes.user).to.be.ok;
-		});
-
-		it('Should not set krux configuration when flag is set to false', () => {
-			const flags = { get: (param) => param === 'krux' ? false : true };
-			const config = oAdsConfig(flags, 'article' );
-
-			expect(config.krux).to.be.false;
-		});
-
-		it('Should not set krux configuration when app requests no targeting', () => {
-			const flags = { get: () => true };
-			const config = oAdsConfig(flags, 'article', { noTargeting: true } );
-
-			expect(config.krux).to.be.false;
-		});
-
 		it('Should set dfp_targeting config', () => {
 			const flags = { get: () => true };
 			const config = oAdsConfig(flags, 'article' );
@@ -95,10 +71,10 @@ describe('Config', () => {
 			sandbox.stub(utils, 'getMetaData').callsFake((param) => {
 				switch (param) {
 					case 'dfp_site':
-							return 'testDfpSite';
+						return 'testDfpSite';
 						break;
 					case 'dfp_zone':
-							return 'testDfpZone';
+						return 'testDfpZone';
 						break;
 				}
 			});
@@ -112,7 +88,7 @@ describe('Config', () => {
 
 	describe('lazyLoad viewportMargin', () => {
 
-	// tests for adOptimizeLazyLoad flag
+		// tests for adOptimizeLazyLoad flag
 		it('Should pass 0% when screen size is wider than 980px', () => {
 			sandbox.stub(utils, 'getScreenSize').callsFake(() => { return 980; });
 			const flags = { get: () => true };


### PR DESCRIPTION
Compared to `v12.8`, version `13.1` of `o-ads` does the following:

1) removes support for 'Krux' as it's no longer used
2) and  adds support for new `addClass` functionality which enables `o-ads` to add a new class to the container slot if instructed by the creative wrapper sent from the ad server.  This will enable the new "sticky" ad functionality.