### PR TITLE
Upgrade o-ads to v12.11.3

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -22,7 +22,7 @@
     "n-topic-search": "^1.0.3",
     "n-ui-foundations": "^3.0.6",
     "next-session-client": "^2.3.4",
-    "o-ads": "^12.8.0",
+    "o-ads": "^12.11.3",
     "o-permutive": "^v1.0.3",
     "o-errors": "^3.6.1",
     "o-expander": "^4.4.4",


### PR DESCRIPTION
This update enables `o-ads` to add a new class to the container slot if instructed by the creative wrapper sent from the ad server.  This will enable the new "sticky" ad functionality.