### PR TITLE
Remove account settings and portfolio from nav bar

### DIFF
--- a/components/n-ui/header/partials/header/nav.html
+++ b/components/n-ui/header/partials/header/nav.html
@@ -36,14 +36,6 @@
 						<a class="o-header__nav-button" href="{{url}}" role="button" data-trackable="{{label}}">{{label}}</a>
 					</li>
 					{{/with}}
-				{{else}}
-					{{#unless @root.flags.accountNavOnMyft}}
-						{{#each @root.navigation.menus.navbar-right.items}}
-							<li class="o-header__nav-item">
-								<a class="o-header__nav-link" href="{{url}}" data-trackable="{{label}}">{{label}}</a>
-							</li>
-						{{/each}}
-					{{/unless}}
 				{{/if}}
 			</ul>
 		{{/unlessEquals}}


### PR DESCRIPTION
It's in the myFT menu now.

Related: https://github.com/Financial-Times/next-myft-page/pull/2124

Trello: https://trello.com/c/J7m239TK/3782-release-navonmyft-to-all-users
