### PR TITLE
Bump `n-express` version

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "supertest": "^3.1.0"
   },
   "dependencies": {
-    "@financial-times/n-express": "^19.22.2",
+    "@financial-times/n-express": "^19.22.3",
     "@financial-times/n-feedback": "^4.6.2",
     "@financial-times/n-handlebars": "^1.21.0",
     "@financial-times/next-json-ld": "^0.4.0",


### PR DESCRIPTION
To pick up changes made to `next-metrics` which clear some failing health checks for `next-syn-list`.