### PR TITLE
Bump o-ads to v12.12 

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -22,7 +22,7 @@
     "n-topic-search": "^1.0.3",
     "n-ui-foundations": "^3.0.6",
     "next-session-client": "^2.3.4",
-    "o-ads": "^12.11.4",
+    "o-ads": "^12.12.0",
     "o-permutive": "^v1.0.3",
     "o-errors": "^3.6.1",
     "o-expander": "^4.4.4",


### PR DESCRIPTION
The new version of o-ads adds some protection against a visual bug introduced by Google in GPT