### PR TITLE
Use the new Google robots meta tag attributes

### DIFF
--- a/browser/layout/wrapper.html
+++ b/browser/layout/wrapper.html
@@ -82,6 +82,7 @@
 		{{#if @root.flags.googleSiteVerificationMeta}}
 		<meta name="google-site-verification" content="4-t8sFaPvpO5FH_Gnw1dkM28CQepjzo8UjjAkdDflTw" />
 		{{/if}}
+		<meta name="robots" content="max-snippet:200, max-image-preview:large">
 
 		{{#outputBlock 'head'}}{{/outputBlock}}
 


### PR DESCRIPTION
Google has introduced new robots meta tag attributes, specifically `max-snippet` and `max-image-preview`. These settings will hopefully improve our SEO performance.

See the [Google doc](https://webmasters.googleblog.com/2019/09/more-controls-on-search.html?utm_source=wnc_20103768&utm_medium=gamma&utm_campaign=wnc_20103768&utm_content=msg_110260908&hl=en-GB) for more on these attributes.

Talk to me, Matt Bailey (Product Manager) or James Webb if you have any
questions about this.

Page Kit PR for the future: https://github.com/Financial-Times/dotcom-page-kit/pull/618