### PR TITLE
Revert "Remove account settings and portfolio from nav bar"

### DIFF
--- a/components/n-ui/header/partials/header/nav.html
+++ b/components/n-ui/header/partials/header/nav.html
@@ -36,6 +36,14 @@
 						<a class="o-header__nav-button" href="{{url}}" role="button" data-trackable="{{label}}">{{label}}</a>
 					</li>
 					{{/with}}
+				{{else}}
+					{{#unless @root.flags.accountNavOnMyft}}
+						{{#each @root.navigation.menus.navbar-right.items}}
+							<li class="o-header__nav-item">
+								<a class="o-header__nav-link" href="{{url}}" data-trackable="{{label}}">{{label}}</a>
+							</li>
+						{{/each}}
+					{{/unless}}
 				{{/if}}
 			</ul>
 		{{/unlessEquals}}


### PR DESCRIPTION
We're now reintroducing this back to the nav bar