### PR TITLE
Oadsv14 compatibility

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -22,7 +22,7 @@
     "n-topic-search": "^2.0.0",
     "n-ui-foundations": "^4.0.0-beta.2",
     "next-session-client": "^2.3.4",
-    "o-ads": "^14.0.0",
+    "o-ads": "^14.1.0",
     "o-date": "^4.0.0",
     "o-permutive": "^1.0.7",
     "o-errors": "^4.0.2",

--- a/components/n-ui/ads/index.js
+++ b/components/n-ui/ads/index.js
@@ -4,7 +4,7 @@ import oPermutive from 'o-permutive';
 //TODO move to central shared utils
 import utils from './js/utils';
 import oAdsConfig from './js/oAdsConfig';
-import { getOPermutiveConfig, /*getOPermutiveMetaData*/ } from './js/oPermutiveConfig';
+import { getOPermutiveConfig, getOPermutiveMetaData } from './js/oPermutiveConfig';
 import { setupAdsMetrics } from './js/ads-metrics';
 import nCounterAdBlocking from 'n-counter-ad-blocking';
 
@@ -57,14 +57,14 @@ export default {
 						// o-permutive
 						.then(() => {
 							if (flags && flags.get('AdsPermutive')) {
-								// const contentId = (appInfo.name === 'article')
-								// 	? document.documentElement.getAttribute('data-content-id')
-								// 	: null;
+								const contentId = (appInfo.name === 'article')
+								? document.documentElement.getAttribute('data-content-id')
+								: null;
 
 								const oPermutiveConfig = getOPermutiveConfig();
 								oPermutive.init(oPermutiveConfig);
 
-								// const metaData = getOPermutiveMetaData(appInfo.name, Ads.krux.customAttributes, contentId);
+								const metaData = getOPermutiveMetaData(appInfo.name, Ads.config('permutive'), contentId);
 								const metaData = {};
 								const spId = Ads.targeting.get().device_spoor_id;
 								const gId = Ads.targeting.get().guid;

--- a/components/n-ui/ads/index.js
+++ b/components/n-ui/ads/index.js
@@ -65,7 +65,6 @@ export default {
 								oPermutive.init(oPermutiveConfig);
 
 								const metaData = getOPermutiveMetaData(appInfo.name, Ads.config('permutive'), contentId);
-								const metaData = {};
 								const spId = Ads.targeting.get().device_spoor_id;
 								const gId = Ads.targeting.get().guid;
 								let userIdent = [];

--- a/components/n-ui/ads/index.js
+++ b/components/n-ui/ads/index.js
@@ -58,13 +58,13 @@ export default {
 						.then(() => {
 							if (flags && flags.get('AdsPermutive')) {
 								const contentId = (appInfo.name === 'article')
-								? document.documentElement.getAttribute('data-content-id')
-								: null;
+									? document.documentElement.getAttribute('data-content-id')
+									: null;
 
 								const oPermutiveConfig = getOPermutiveConfig();
 								oPermutive.init(oPermutiveConfig);
 
-								const metaData = getOPermutiveMetaData(appInfo.name, Ads.config('permutive'), contentId);
+								const metaData = getOPermutiveMetaData(appInfo.name, Ads.config('behavioralMeta'), contentId);
 								const spId = Ads.targeting.get().device_spoor_id;
 								const gId = Ads.targeting.get().guid;
 								let userIdent = [];

--- a/components/n-ui/ads/js/oPermutiveConfig.js
+++ b/components/n-ui/ads/js/oPermutiveConfig.js
@@ -30,13 +30,9 @@ export function getOPermutiveMetaData (appName, permMeta, contentId = null) {
 	if(appName === 'article') {
 		const permPageMeta = permMeta.page;
 
-		if(contentId) {
-			pageMeta.id = contentId;
-		}
-
 		if(permPageMeta) {
 			const type = Array.isArray(permPageMeta.genre) && permPageMeta.genre.length > 0 ? permPageMeta.genre[0] : null;
-
+  
 			pageMeta = {
 				id: contentId,
 				type: type,

--- a/components/n-ui/ads/js/oPermutiveConfig.js
+++ b/components/n-ui/ads/js/oPermutiveConfig.js
@@ -21,45 +21,45 @@ export function getOPermutiveConfig () {
  *
  * @param {String} appName Name of the app loading n-ui
  */
-export function getOPermutiveMetaData (appName, kruxMeta, contentId = null) {
+export function getOPermutiveMetaData (appName, permMeta, contentId = null) {
 	let pageMeta = {};
 	let userMeta = {};
 
-	const kruxUserMeta = kruxMeta.user;
+	const permUserMeta = permMeta.user;
 
 	if(appName === 'article') {
-		const kruxPageMeta = kruxMeta.page;
+		const permPageMeta = permMeta.page;
 
 		if(contentId) {
 			pageMeta.id = contentId;
 		}
-
-		if(kruxPageMeta) {
-			const type = Array.isArray(kruxPageMeta.genre) && kruxPageMeta.genre.length > 0 ? kruxPageMeta.genre[0] : null;
-
-			pageMeta = {
-				id: contentId,
-				type: type,
-				organisations: kruxPageMeta.organisations,
-				people: kruxPageMeta.people,
-				categories: kruxPageMeta.ca,
-				authors: kruxPageMeta.authors,
-				topics: kruxPageMeta.topics,
-				admants: kruxPageMeta.ad
+		
+			if(permPageMeta) {
+				const type = Array.isArray(permPageMeta.genre) && permPageMeta.genre.length > 0 ? permPageMeta.genre[0] : null;
+	
+				pageMeta = {
+					id: contentId,
+					type: type,
+					organisations: permPageMeta.organisations,
+					people: permPageMeta.people,
+					categories: permPageMeta.ca,
+					authors: permPageMeta.authors,
+					topics: permPageMeta.topics,
+					admants: permPageMeta.ad
+				};
+			}
+		}
+	
+		if(permUserMeta) {
+			userMeta = {
+				industry: permUserMet.industry,
+				position: permUserMet.job_position,
+				responsibility: permUserMet.job_responsibility,
+				gender: permUserMet.gender,
+				subscriptionLevel: permUserMet.subscription_level,
+				indb2b: permUserMet.indb2b
 			};
 		}
-	}
-
-	if(kruxUserMeta) {
-		userMeta = {
-			industry: kruxUserMeta.industry,
-			position: kruxUserMeta.job_position,
-			responsibility: kruxUserMeta.job_responsibility,
-			gender: kruxUserMeta.gender,
-			subscriptionLevel: kruxUserMeta.subscription_level,
-			indb2b: kruxUserMeta.indb2b
-		};
-	}
 
 
 	return {

--- a/components/n-ui/ads/js/oPermutiveConfig.js
+++ b/components/n-ui/ads/js/oPermutiveConfig.js
@@ -25,37 +25,36 @@ export function getOPermutiveMetaData (appName, permMeta, contentId = null) {
 	let pageMeta = {};
 	let userMeta = {};
 
-	const permUserMeta = permMeta.user;
+	//const permUserMeta = permMeta && permMeta.user;
 
 	if(appName === 'article') {
-		const permPageMeta = permMeta.page;
+		//const permPageMeta = permMeta.page;
 
-		if(permPageMeta) {
-			const type = Array.isArray(permPageMeta.genre) && permPageMeta.genre.length > 0 ? permPageMeta.genre[0] : null;
+		if(permMeta && permMeta.page) {
+			const type = Array.isArray(permMeta.page.genre) && permMeta.page.genre.length > 0 ? permMeta.page.genre[0] : null;
 			pageMeta = {
 				id: contentId,
 				type: type,
-				organisations: permPageMeta.organisations,
-				people: permPageMeta.people,
-				categories: permPageMeta.ca,
-				authors: permPageMeta.authors,
-				topics: permPageMeta.topics,
-				admants: permPageMeta.ad
+				organisations: permMeta.page.organisations,
+				people: permMeta.page.people,
+				categories: permMeta.page.ca,
+				authors: permMeta.page.authors,
+				topics: permMeta.page.topics,
+				admants: permMeta.page.ad
 			};
 		}
 	}
 
-	if(permUserMeta) {
+	if(permMeta && permMeta.user) {
 		userMeta = {
-			industry: permUserMeta.industry,
-			position: permUserMeta.job_position,
-			responsibility: permUserMeta.job_responsibility,
-			gender: permUserMeta.gender,
-			subscriptionLevel: permUserMeta.subscription_level,
-			indb2b: permUserMeta.indb2b
+			industry: permMeta.user.industry,
+			position: permMeta.user.job_position,
+			responsibility: permMeta.user.job_responsibility,
+			gender: permMeta.user.gender,
+			subscriptionLevel: permMeta.user.subscription_level,
+			indb2b: permMeta.user.indb2b
 		};
 	}
-
 
 	return {
 		page: {

--- a/components/n-ui/ads/js/oPermutiveConfig.js
+++ b/components/n-ui/ads/js/oPermutiveConfig.js
@@ -33,33 +33,33 @@ export function getOPermutiveMetaData (appName, permMeta, contentId = null) {
 		if(contentId) {
 			pageMeta.id = contentId;
 		}
-		
-			if(permPageMeta) {
-				const type = Array.isArray(permPageMeta.genre) && permPageMeta.genre.length > 0 ? permPageMeta.genre[0] : null;
-	
-				pageMeta = {
-					id: contentId,
-					type: type,
-					organisations: permPageMeta.organisations,
-					people: permPageMeta.people,
-					categories: permPageMeta.ca,
-					authors: permPageMeta.authors,
-					topics: permPageMeta.topics,
-					admants: permPageMeta.ad
-				};
-			}
-		}
-	
-		if(permUserMeta) {
-			userMeta = {
-				industry: permUserMet.industry,
-				position: permUserMet.job_position,
-				responsibility: permUserMet.job_responsibility,
-				gender: permUserMet.gender,
-				subscriptionLevel: permUserMet.subscription_level,
-				indb2b: permUserMet.indb2b
+
+		if(permPageMeta) {
+			const type = Array.isArray(permPageMeta.genre) && permPageMeta.genre.length > 0 ? permPageMeta.genre[0] : null;
+
+			pageMeta = {
+				id: contentId,
+				type: type,
+				organisations: permPageMeta.organisations,
+				people: permPageMeta.people,
+				categories: permPageMeta.ca,
+				authors: permPageMeta.authors,
+				topics: permPageMeta.topics,
+				admants: permPageMeta.ad
 			};
 		}
+	}
+
+	if(permUserMeta) {
+		userMeta = {
+			industry: permUserMeta.industry,
+			position: permUserMeta.job_position,
+			responsibility: permUserMeta.job_responsibility,
+			gender: permUserMeta.gender,
+			subscriptionLevel: permUserMeta.subscription_level,
+			indb2b: permUserMeta.indb2b
+		};
+	}
 
 
 	return {

--- a/components/n-ui/ads/js/oPermutiveConfig.js
+++ b/components/n-ui/ads/js/oPermutiveConfig.js
@@ -32,7 +32,6 @@ export function getOPermutiveMetaData (appName, permMeta, contentId = null) {
 
 		if(permPageMeta) {
 			const type = Array.isArray(permPageMeta.genre) && permPageMeta.genre.length > 0 ? permPageMeta.genre[0] : null;
-  
 			pageMeta = {
 				id: contentId,
 				type: type,

--- a/components/n-ui/ads/test/helpers/markup.js
+++ b/components/n-ui/ads/test/helpers/markup.js
@@ -11,7 +11,7 @@ function set (markup) {
 
 function destroyContainer () {
 	if (container.parentNode) {
-			container.parentNode.removeChild(container);
+		container.parentNode.removeChild(container);
 	}
 }
 

--- a/components/n-ui/ads/test/oAdsConfig.spec.js
+++ b/components/n-ui/ads/test/oAdsConfig.spec.js
@@ -71,10 +71,10 @@ describe('Config', () => {
 			sandbox.stub(utils, 'getMetaData').callsFake((param) => {
 				switch (param) {
 					case 'dfp_site':
-							return 'testDfpSite';
+						return 'testDfpSite';
 						break;
 					case 'dfp_zone':
-							return 'testDfpZone';
+						return 'testDfpZone';
 						break;
 				}
 			});
@@ -88,7 +88,7 @@ describe('Config', () => {
 
 	describe('lazyLoad viewportMargin', () => {
 
-	// tests for adOptimizeLazyLoad flag
+		// tests for adOptimizeLazyLoad flag
 		it('Should pass 0% when screen size is wider than 980px', () => {
 			sandbox.stub(utils, 'getScreenSize').callsFake(() => { return 980; });
 			const flags = { get: () => true };

--- a/components/n-ui/tracking/ft/events/navigation-timing.js
+++ b/components/n-ui/tracking/ft/events/navigation-timing.js
@@ -49,7 +49,7 @@ const getMarks = performance =>
 				marks[mark.name] = Math.round(mark.startTime);
 				return marks;
 			}, {}) :
-	{};
+		{};
 
 const getCustom = (window, performance) => {
 	const custom = {};

--- a/components/n-ui/tracking/test/ft/utils/getDomPath.spec.js
+++ b/components/n-ui/tracking/test/ft/utils/getDomPath.spec.js
@@ -81,6 +81,6 @@ describe('getDomPath', function () {
 												</section>`;
 		const path = getDomPath(document.getElementById('x1'), []);
 		expect(path).to.deep.equal(['b', 'c']);
-	expect(document.getElementById('x2').getAttribute('data-trackable')).to.equal('b');
+		expect(document.getElementById('x2').getAttribute('data-trackable')).to.equal('b');
 	});
 });


### PR DESCRIPTION
Oads is being bumped from v12 to v14 - This PR updates the way user and content metaData is handled from the` o-ads/dataproviders/api module` to ensure compatibility with o-ads v13 and above.

Specifically, o-ads makes an a fetch request to the ads-api, the api end-point returns json which is passed on to Permutive tracking calls in the oPermutiveConfig module. 