### PR TITLE
Use the default export for o-tracking

### DIFF
--- a/components/n-ui/tracking/ft/events/audio-teaser-view.js
+++ b/components/n-ui/tracking/ft/events/audio-teaser-view.js
@@ -1,4 +1,4 @@
-const oTracking = require('o-tracking');
+const oTracking = require('o-tracking').default;
 
 const audioTeaserView = {
 	init: (selector) => {


### PR DESCRIPTION
This breaks otherwise.