### PR TITLE
Remove adsDisableCookieConsent flag 🐿 v2.12.5

### DIFF
--- a/components/n-ui/ads/js/oAdsConfig.js
+++ b/components/n-ui/ads/js/oAdsConfig.js
@@ -117,7 +117,7 @@ export default function (flags, appName, adOptions) {
 			page: getContextualTargeting(appName),
 			usePageZone: true
 		},
-		disableConsentCookie: flags.get('adsDisableCookieConsent'),
+		disableConsentCookie: false,
 		validateAdsTraffic: flags.get('moatAdsTraffic')
 	};
 };


### PR DESCRIPTION
Removing the adsDisableCookieConsent flag as it's not longer needed. We pass false to the `disableConsentCookie` setting of o-ads to tell it to always use the ft cookie for consent. This feature was built into o-ads to allow for third party sites to use o-ads with their own consent mechanism.