### PR TITLE
Fix current year test 🐿 v2.12.5

### DIFF
--- a/server/test/current-year.test.js
+++ b/server/test/current-year.test.js
@@ -26,14 +26,14 @@ describe('current year middleware', () => {
 			.end(done);
 	});
 
-	it('should set the res.locals.currentYear property to 2019', (done) => {
+	it('should set the res.locals.currentYear property to 2020', (done) => {
 		request(app)
 			.get('/')
 			.expect(() => {
 				expect(locals).to.have.own.property('currentYear');
 				// this will break every year, but better to be sure it's working
 				// than using the same code logic to validate the year
-				expect(locals.currentYear).to.equal(2019);
+				expect(locals.currentYear).to.equal(2020);
 			})
 			.end(done);
 	});


### PR DESCRIPTION
This updates one of the tests which checked for current year = 2019. Updated to 2020.