### PR TITLE
Disable GTM for pa11y tests

### DIFF
--- a/browser/layout/pa11y-config.js
+++ b/browser/layout/pa11y-config.js
@@ -6,7 +6,7 @@ module.exports = {
 	pa11yData: [
 		{
 			rootElement: 'html',
-			hideElements: '.n-skip-link',
+			hideElements: '.n-skip-link, iframe[src*=doubleclick]',
 			page: {
 				headers: {
 					'FT-Flags': 'ads:off,javascript:off'
@@ -15,7 +15,7 @@ module.exports = {
 		},
 		{
 			rootElement: 'html',
-			hideElements: '.n-skip-link',
+			hideElements: '.n-skip-link, iframe[src*=doubleclick]',
 			page: {
 				headers: {
 					'FT-Flags': 'ads:off,javascript:on'

--- a/browser/layout/pa11y-config.js
+++ b/browser/layout/pa11y-config.js
@@ -6,7 +6,7 @@ module.exports = {
 	pa11yData: [
 		{
 			rootElement: 'html',
-			hideElements: '.n-skip-link, iframe[src*=doubleclick]',
+			hideElements: '.n-skip-link',
 			page: {
 				headers: {
 					'FT-Flags': 'ads:off,javascript:off,enableGTM:off'
@@ -15,7 +15,7 @@ module.exports = {
 		},
 		{
 			rootElement: 'html',
-			hideElements: '.n-skip-link, iframe[src*=doubleclick]',
+			hideElements: '.n-skip-link',
 			page: {
 				headers: {
 					'FT-Flags': 'ads:off,javascript:on,enableGTM:off'

--- a/browser/layout/pa11y-config.js
+++ b/browser/layout/pa11y-config.js
@@ -9,7 +9,7 @@ module.exports = {
 			hideElements: '.n-skip-link, iframe[src*=doubleclick]',
 			page: {
 				headers: {
-					'FT-Flags': 'ads:off,javascript:off'
+					'FT-Flags': 'ads:off,javascript:off,enableGTM:off'
 				}
 			}
 		},
@@ -18,7 +18,7 @@ module.exports = {
 			hideElements: '.n-skip-link, iframe[src*=doubleclick]',
 			page: {
 				headers: {
-					'FT-Flags': 'ads:off,javascript:on'
+					'FT-Flags': 'ads:off,javascript:on,enableGTM:off'
 				}
 			}
 		}

--- a/components/n-ui/header/pa11y-config.js
+++ b/components/n-ui/header/pa11y-config.js
@@ -6,35 +6,35 @@ module.exports = {
 		{
 			rootElement: '.n-layout__row--header',
 			// Hide elements that depend on other components’ markup
-			hideElements: '.n-skip-link, [href="#o-header-drawer"],iframe[src*=doubleclick]',
+			hideElements: '.n-skip-link, [href="#o-header-drawer"]',
 			headers: {
-				'FT-Flags': 'ads:off,sourcepoint:off,javascript:on'
+				'FT-Flags': 'ads:off,sourcepoint:off,javascript:on,enableGTM:off'
 			}
 		},
 		{
 			rootElement: '.n-layout__row--header',
 			// Hide elements that depend on other components’ markup
-			hideElements: '.n-skip-link, [href="#o-header-drawer"],iframe[src*=doubleclick]',
+			hideElements: '.n-skip-link, [href="#o-header-drawer"]',
 			headers: {
-				'FT-Flags': 'ads:off,javascript:off'
+				'FT-Flags': 'ads:off,javascript:off,enableGTM:off'
 			}
 		},
 		{
 			rootElement: '.n-layout__row--header',
 			// Hide elements that depend on other components’ markup
-			hideElements: '.n-skip-link, [href="#o-header-drawer"],iframe[src*=doubleclick]',
+			hideElements: '.n-skip-link, [href="#o-header-drawer"]',
 			headers: {
 				'FT-Anonymous-User': true,
-				'FT-Flags': 'ads:off,sourcepoint:off,javascript:on'
+				'FT-Flags': 'ads:off,sourcepoint:off,javascript:on,enableGTM:off'
 			}
 		},
 		{
 			rootElement: '.n-layout__row--header',
 			// Hide elements that depend on other components’ markup
-			hideElements: '.n-skip-link, [href="#o-header-drawer"],iframe[src*=doubleclick]',
+			hideElements: '.n-skip-link, [href="#o-header-drawer"]',
 			headers: {
 				'FT-Anonymous-User': true,
-				'FT-Flags': 'ads:off,javascript:off'
+				'FT-Flags': 'ads:off,javascript:off,enableGTM:off'
 			}
 		}
 	]

--- a/components/n-ui/header/pa11y-config.js
+++ b/components/n-ui/header/pa11y-config.js
@@ -6,7 +6,7 @@ module.exports = {
 		{
 			rootElement: '.n-layout__row--header',
 			// Hide elements that depend on other components’ markup
-			hideElements: '.n-skip-link, [href="#o-header-drawer"]',
+			hideElements: '.n-skip-link, [href="#o-header-drawer"],iframe[src*=doubleclick]',
 			headers: {
 				'FT-Flags': 'ads:off,sourcepoint:off,javascript:on'
 			}
@@ -14,7 +14,7 @@ module.exports = {
 		{
 			rootElement: '.n-layout__row--header',
 			// Hide elements that depend on other components’ markup
-			hideElements: '.n-skip-link, [href="#o-header-drawer"]',
+			hideElements: '.n-skip-link, [href="#o-header-drawer"],iframe[src*=doubleclick]',
 			headers: {
 				'FT-Flags': 'ads:off,javascript:off'
 			}
@@ -22,7 +22,7 @@ module.exports = {
 		{
 			rootElement: '.n-layout__row--header',
 			// Hide elements that depend on other components’ markup
-			hideElements: '.n-skip-link, [href="#o-header-drawer"]',
+			hideElements: '.n-skip-link, [href="#o-header-drawer"],iframe[src*=doubleclick]',
 			headers: {
 				'FT-Anonymous-User': true,
 				'FT-Flags': 'ads:off,sourcepoint:off,javascript:on'
@@ -31,7 +31,7 @@ module.exports = {
 		{
 			rootElement: '.n-layout__row--header',
 			// Hide elements that depend on other components’ markup
-			hideElements: '.n-skip-link, [href="#o-header-drawer"]',
+			hideElements: '.n-skip-link, [href="#o-header-drawer"],iframe[src*=doubleclick]',
 			headers: {
 				'FT-Anonymous-User': true,
 				'FT-Flags': 'ads:off,javascript:off'


### PR DESCRIPTION
Adding the floodlight tag via Google Tag Manager makes a couple of Pa11y test fail ([see this](https://circleci.com/gh/Financial-Times/n-ui/9835))
 
The same way [we did for next-subscribe](https://github.com/Financial-Times/next-subscribe/pull/746/files) , we are now instructing ignoring Pa11y to not look at Doubleclick iframes.

Since ☝️ this doesn't seem to sort out the problem completely, I'm also (temporarily) disabling GTM altogether during pa11y tests the same way we already disable ads. This obviously introduces some blind spots in our a11y testing but I believe this is acceptable for now as n-ui is being phased out. However, I plan to discuss with the a11y team asap to come up with a better solution. 
