### PR TITLE
Bumping o-permutive to latest patch-release to fix a bug where some D…

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -24,7 +24,7 @@
     "next-session-client": "^2.3.4",
     "o-ads": "^14.1.0",
     "o-date": "^4.0.0",
-    "o-permutive": "^1.0.7",
+    "o-permutive": "^1.0.8",
     "o-errors": "^4.0.2",
     "o-expander": "^5.0.0",
     "o-footer": "^7.0.1",


### PR DESCRIPTION
Bumping o-permutive to latest patch-release to fix a bug where some DFP integration code would run when a user opted-out of  BehavioralOnsitAds - see: https://financialtimes.atlassian.net/secure/RapidBoard.jspa?rapidView=803&projectKey=ADSDEV&modal=detail&selectedIssue=ADSDEV-282 for further details of the bug that has been patched in o-permutive.
🐿 v2.12.5