### PR TITLE
Marks n-ui as Decommissioned in runbook.md 🐿 v2.12.6

### DIFF
--- a/runbook.md
+++ b/runbook.md
@@ -1,9 +1,8 @@
 # Next n-ui
 
+_NOTE_ n-ui has been now been replaced with [Page Kit](https://biz-ops.in.ft.com/Repository/github%3AFinancial-Times%2Fdotcom-page-kit) in ft.com applications.
+
 Server, build and client side bootstrapping for ft.com’s user-facing applications. Most of the user-facing apps on ft.com currently rely on n-ui, it is a critical part of our infrastructure.
-
-_NOTE_: n-ui has been now been replaced with [Page Kit](https://biz-ops.in.ft.com/Repository/github%3AFinancial-Times%2Fdotcom-page-kit) in ft.com applications._
-
 
 ## Primary URL
 
@@ -15,7 +14,7 @@ Bronze
 
 ## Lifecycle Stage
 
-Deprecated
+Decommissioned
 
 ## Delivered By
 


### PR DESCRIPTION
Updates the lifecycle stage from `Deprecated` to `Decommissioned` so that it can be picked up correctly by runbook.md